### PR TITLE
Add logged message purge by count

### DIFF
--- a/cogs/moderation/clean.py
+++ b/cogs/moderation/clean.py
@@ -170,8 +170,9 @@ class Clean(commands.Cog):
 
                 async def confirmation_callback(value: Optional[bool]):
                     if value:
-                        deleted_messages = await channel.purge(limit=count)
-                        deleted_count = len(deleted_messages)  # Obtenir le nombre de messages supprimés
+                        deleted_count = await CleanService.delete_last_messages(
+                            channel, count, interaction.user
+                        )
                         await interaction.followup.send(
                             f"{deleted_count} derniers messages supprimés dans {channel.mention}.",
                             ephemeral=True

--- a/cogs/moderation/services/clean_service.py
+++ b/cogs/moderation/services/clean_service.py
@@ -57,6 +57,31 @@ class CleanService:
             raise
 
     @staticmethod
+    async def delete_last_messages(channel: discord.TextChannel, count: int, deleted_by: discord.Member) -> int:
+        """Supprime un nombre spécifique de messages et enregistre l'action."""
+        try:
+            deleted = await channel.purge(limit=count)
+            logger.info(
+                f"{len(deleted)} messages supprimés dans {channel.name} par {deleted_by} (dernier {count})."
+            )
+
+            await database.log_message_deletion(
+                deleted_by=deleted_by.id,
+                channel=channel.name,
+                guild=channel.guild.name,
+                deletion_type="number",
+                target_user=None,
+                message_count=len(deleted),
+            )
+            return len(deleted)
+        except discord.Forbidden:
+            logger.error(f"Permissions insuffisantes pour supprimer les messages dans {channel.name}.")
+            raise
+        except discord.HTTPException as e:
+            logger.error(f"Erreur HTTP lors de la suppression des messages dans {channel.name}: {e}")
+            raise
+
+    @staticmethod
     async def delete_messages_after(channel: discord.TextChannel, message_id: int, deleted_by: discord.Member) -> int:
         """Supprime les messages après un message spécifique et enregistre l'action."""
         try:


### PR DESCRIPTION
## Summary
- add `delete_last_messages` in `CleanService`
- use `delete_last_messages` in `clean_execute` for numbered purges

## Testing
- `python -m py_compile cogs/moderation/services/clean_service.py cogs/moderation/clean.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'asyncpg')*

------
https://chatgpt.com/codex/tasks/task_e_684061c9c0d883289d05b4aafc7e5002