### PR TITLE
Refactor stalker daily update

### DIFF
--- a/cogs/accueil/services/accueil_services.py
+++ b/cogs/accueil/services/accueil_services.py
@@ -1,5 +1,5 @@
 #cogs\accueil\services\accueil_services.py
-from datetime import date, datetime
+from datetime import datetime
 from typing import Dict, List, Optional, Tuple
 from zoneinfo import ZoneInfo
 from utils.database import database
@@ -282,14 +282,14 @@ async def get_period_stats(guild_id: int, days: Optional[int]) -> dict:
         record = await database.fetchrow(query, server_id)
     else:
         # sur X jours
-        query = f"""
+        query = """
             SELECT COALESCE(SUM(join_count), 0) AS join_count,
                    COALESCE(SUM(leave_count), 0) AS leave_count
             FROM member_daily_stats
             WHERE guild_id = $1
-              AND date >= (CURRENT_DATE - {days})
+              AND date >= (CURRENT_DATE - $2::integer)
         """
-        record = await database.fetchrow(query, server_id)
+        record = await database.fetchrow(query, server_id, days)
 
     if not record:
         return {"join_count": 0, "leave_count": 0, "join_leave_ratio": 0}

--- a/cogs/accueil/stalker.py
+++ b/cogs/accueil/stalker.py
@@ -5,9 +5,8 @@ import logging
 import io
 from matplotlib import ticker
 import matplotlib.pyplot as plt
-from datetime import timedelta, date, datetime, time
+from datetime import datetime, time
 from zoneinfo import ZoneInfo
-import asyncio
 
 from cogs.accueil.services import accueil_services
 
@@ -62,7 +61,6 @@ class StalkerCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self.channel_id = 1236437099310219336
-        self.leave_thread_name = "Notifications départs"
         self.persistent_message = None
 
         # Tâche de mise à jour quotidienne
@@ -248,30 +246,15 @@ class StalkerCog(commands.Cog):
         except Exception as e:
             logger.error(f"Erreur lors de la mise à jour de l'embed : {e}")
 
-    @tasks.loop()
+    @tasks.loop(time=time(hour=0, tzinfo=ZoneInfo("Europe/Paris")))
     async def daily_update(self):
-        """
-        Mise à jour quotidienne de l'embed à 00h00 (heure de Paris).
-        """
-        while True:
+        """Met à jour l'embed de statistiques chaque jour à minuit."""
+        for guild in self.bot.guilds:
             try:
-                paris_tz = ZoneInfo("Europe/Paris")
-                now = datetime.now(paris_tz)
-                logger.debug(f"Heure actuelle à Paris: {now}")
-
-                next_midnight = datetime.combine(now.date() + timedelta(days=1), time.min, tzinfo=paris_tz)
-                delta_seconds = (next_midnight - now).total_seconds()
-                logger.debug(f"Délai jusqu'au prochain minuit: {delta_seconds} secondes")
-                await asyncio.sleep(delta_seconds)
-
-                for guild in self.bot.guilds:
-                    # Pour la mise à jour quotidienne, on garde la "période défaut" = 30 jours
-                    await self.update_stats_embed(guild, period="default")
-
-                logger.info("Mise à jour quotidienne de l'embed effectuée.")
+                await self.update_stats_embed(guild, period="default")
             except Exception as e:
-                logger.error(f"Erreur dans la tâche quotidienne: {e}")
-                await asyncio.sleep(60)
+                logger.error(f"Erreur lors de la mise à jour quotidienne pour {guild.id}: {e}")
+        logger.info("Mise à jour quotidienne de l'embed effectuée.")
 
     @daily_update.before_loop
     async def before_daily_update(self):


### PR DESCRIPTION
## Summary
- clean unused imports in stalker and service modules
- refactor daily update loop to run once per day using `tasks.loop`
- parameterise query in `get_period_stats`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'asyncpg')*

------
https://chatgpt.com/codex/tasks/task_e_6840690891c483288907693ae566a99d