### PR TITLE
Add rule and account checks

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -7,6 +7,7 @@ import asyncio
 import os
 from config import DISCORD_TOKEN, TEST_GUILD_ID, LOGGING, TEST_MODE
 from utils.database import database
+from utils.checks import rules_check, rules_interaction_check
 from cogs.other.online_count_updater import setup_rank_updater, teardown_rank_updater, rank_updater
 
 def configure_logging():
@@ -51,6 +52,11 @@ intents.message_content = True
 
 # On crée le bot
 bot = commands.Bot(command_prefix='!', intents=intents)
+bot.check(rules_check())
+
+@bot.tree.interaction_check
+async def _global_rules_check(interaction: discord.Interaction) -> bool:
+    return await rules_interaction_check(interaction)
 
 # On attache un logger "bot" à l'instance
 logger = logging.getLogger('bot')

--- a/cogs/ranking/assign_rank.py
+++ b/cogs/ranking/assign_rank.py
@@ -16,7 +16,6 @@ from cogs.ranking.services.assign_rank_service import (
     get_role_mappings,
     refresh_role_mappings,
     delete_valo_data,
-    user_exists_in_db,
     get_role_id_for_config,
     get_or_create_server_record,
     get_user_by_pseudo_tag,
@@ -28,6 +27,7 @@ from cogs.ranking.services.valorant_service import (
 )
 from cogs.moderation.services.moderation_service import ModerationService
 from utils.database import database
+from utils.checks import rules_interaction_check
 import logging
 import asyncio
 from datetime import datetime, timedelta
@@ -133,15 +133,7 @@ class PseudoTagModal(discord.ui.Modal, title="Renseignez votre Pseudo et Tag Val
                 await self.cog.notify_duplicate_pseudo_tag(existing_user, self.user, pseudo, tag)
                 return
 
-        exists = await user_exists_in_db(interaction.user.id)
-        if not exists:
-            rules_channel_id = await get_rules_channel_id(interaction.guild_id)
-            if rules_channel_id:
-                channel_mention = f"<#{rules_channel_id}>"
-                msg = f"Veuillez d'abord accepter le règlement ici : {channel_mention}"
-            else:
-                msg = "Veuillez d'abord accepter le règlement (salon introuvable)."
-            await interaction.response.send_message(msg, ephemeral=True)
+        if not await rules_interaction_check(interaction):
             return
 
         try:

--- a/cogs/ranking/mmr_tracker.py
+++ b/cogs/ranking/mmr_tracker.py
@@ -16,6 +16,7 @@ from typing import List, Optional
 import numpy as np
 
 from cogs.ranking.services.mmr_tracker_service import ValorantService
+from utils.checks import valorant_link_required
 
 logger = logging.getLogger('valorant_mmr')
 
@@ -92,6 +93,7 @@ class MMRTracker(commands.Cog):
             await ValorantService.insert_history_entry(user_id, entry)
 
     @app_commands.command(name="mmr_track", description="Gérer le suivi MMR : activer, désactiver ou afficher les stats.")
+    @valorant_link_required()
     @app_commands.describe(periode="Période à afficher (today, week, all, ou episode/act)")
     @app_commands.choices(action=ACTION_CHOICES)
     async def mmr_track(

--- a/cogs/ranking/services/assign_rank_service.py
+++ b/cogs/ranking/services/assign_rank_service.py
@@ -338,6 +338,20 @@ async def user_exists_in_db(discord_id: int) -> bool:
     record = await database.fetchrow(query, discord_id)
     return record is not None
 
+async def valorant_account_linked(discord_id: int) -> bool:
+    """Vérifie si l'utilisateur possède une entrée dans ``valorant_info``."""
+    user_pk = await get_user_pk_by_discord_id(discord_id)
+    if not user_pk:
+        return False
+    query = """
+        SELECT 1
+          FROM valorant_info
+         WHERE user_id = $1
+         LIMIT 1
+    """
+    record = await database.fetchrow(query, user_pk)
+    return record is not None
+
 # ------------------------------------------------
 # RÔLES : gestion + cache local
 # ------------------------------------------------

--- a/cogs/scrims/scrims.py
+++ b/cogs/scrims/scrims.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo  # Pour le fuseau Europe/Paris
 
 from cogs.scrims.service.scrims_services import ScrimService
+from utils.checks import rules_interaction_check
 
 logger = logging.getLogger("scrims")
 
@@ -243,7 +244,9 @@ class ScrimModal(discord.ui.Modal, title="Créer un scrim"):
 
     async def on_submit(self, interaction: discord.Interaction):
         await interaction.response.defer(ephemeral=True)
-        
+        if not await rules_interaction_check(interaction):
+            return
+
         try:
             scrim_datetime = datetime.strptime(f"{self.date.value} {self.heure.value}", "%d/%m/%Y %H:%M")
             from zoneinfo import ZoneInfo
@@ -259,12 +262,7 @@ class ScrimModal(discord.ui.Modal, title="Créer un scrim"):
         creator_discord_id = interaction.user.id
         internal_user_id = await self.service.get_internal_user_id(creator_discord_id)
         if internal_user_id is None:
-            rules_channel_id = 1236392632079618108
-            rules_channel_link = f"https://discord.com/channels/{interaction.guild.id}/{rules_channel_id}"
-            return await interaction.followup.send(
-                f"Veuillez d'abord accepter le règlement {rules_channel_link}.",
-                ephemeral=True
-            )
+            return await interaction.followup.send("Erreur : utilisateur non trouvé.", ephemeral=True)
 
         # Lors de la création, le créateur est ajouté par défaut dans team1
         scrim_id = await self.service.create_scrim(
@@ -304,15 +302,12 @@ class ScrimView(discord.ui.View):
     @discord.ui.button(label="Rejoindre Équipe 1", style=discord.ButtonStyle.success, custom_id="join_team1")
     async def join_team1_button(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.defer(ephemeral=True)
+        if not await rules_interaction_check(interaction):
+            return
         service = self.cog.service
         internal_user_id = await service.get_internal_user_id(interaction.user.id)
         if internal_user_id is None:
-            rules_channel_id = 1236392632079618108
-            rules_channel_link = f"https://discord.com/channels/{interaction.guild.id}/{rules_channel_id}"
-            return await interaction.followup.send(
-                f"Veuillez d'abord accepter le règlement {rules_channel_link}.",
-                ephemeral=True
-            )
+            return await interaction.followup.send("Erreur : utilisateur non trouvé.", ephemeral=True)
         if await service.is_user_registered_in_any_team(self.scrim_id, internal_user_id):
             return await interaction.followup.send("Vous êtes déjà inscrit dans une équipe.", ephemeral=True)
         if not await service.add_team_participant(self.scrim_id, "team1", internal_user_id):
@@ -329,15 +324,12 @@ class ScrimView(discord.ui.View):
     @discord.ui.button(label="Rejoindre Équipe 2", style=discord.ButtonStyle.success, custom_id="join_team2")
     async def join_team2_button(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.defer(ephemeral=True)
+        if not await rules_interaction_check(interaction):
+            return
         service = self.cog.service
         internal_user_id = await service.get_internal_user_id(interaction.user.id)
         if internal_user_id is None:
-            rules_channel_id = 1236392632079618108
-            rules_channel_link = f"https://discord.com/channels/{interaction.guild.id}/{rules_channel_id}"
-            return await interaction.followup.send(
-                f"Veuillez d'abord accepter le règlement {rules_channel_link}.",
-                ephemeral=True
-            )
+            return await interaction.followup.send("Erreur : utilisateur non trouvé.", ephemeral=True)
         if await service.is_user_registered_in_any_team(self.scrim_id, internal_user_id):
             return await interaction.followup.send("Vous êtes déjà inscrit dans une équipe.", ephemeral=True)
         if not await service.add_team_participant(self.scrim_id, "team2", internal_user_id):
@@ -354,15 +346,12 @@ class ScrimView(discord.ui.View):
     @discord.ui.button(label="Quitter le scrim", style=discord.ButtonStyle.danger, custom_id="leave_scrim")
     async def leave_button(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.defer(ephemeral=True)
+        if not await rules_interaction_check(interaction):
+            return
         service = self.cog.service
         internal_user_id = await service.get_internal_user_id(interaction.user.id)
         if internal_user_id is None:
-            rules_channel_id = 1236392632079618108
-            rules_channel_link = f"https://discord.com/channels/{interaction.guild.id}/{rules_channel_id}"
-            return await interaction.followup.send(
-                f"Veuillez d'abord accepter le règlement {rules_channel_link}.",
-                ephemeral=True
-            )
+            return await interaction.followup.send("Erreur : utilisateur non trouvé.", ephemeral=True)
         if not await service.is_user_registered_in_any_team(self.scrim_id, internal_user_id):
             return await interaction.followup.send("Vous n'êtes pas inscrit dans une équipe.", ephemeral=True)
         if not await service.remove_team_participant(self.scrim_id, internal_user_id):

--- a/cogs/voice_management/queue_views.py
+++ b/cogs/voice_management/queue_views.py
@@ -8,6 +8,7 @@ from discord import ButtonStyle, Interaction
 from discord.ui import Button, Select, View
 
 from cogs.voice_management.services.five_stack_service import MatchmakingService
+from cogs.ranking.services.assign_rank_service import valorant_account_linked
 
 # Constante pour l'ID du salon où l'utilisateur doit lier ses informations Valorant
 VALORANT_INFO_CHANNEL_ID: int = 1323673115922010143
@@ -186,15 +187,15 @@ class TeamSizeSelect(Select):
                 )
                 return
 
-            # Récupération des informations Valorant de l'utilisateur
-            user_info = await MatchmakingService.get_user_info(user.id)
-            if not user_info:
+            # Vérification de la présence des infos Valorant
+            if not await valorant_account_linked(user.id):
                 await interaction.followup.send(
-                    f"Vous n'avez pas encore configuré vos informations Valorant. "
                     f"Veuillez lier votre compte dans le salon <#{VALORANT_INFO_CHANNEL_ID}> avant de rejoindre la queue.",
                     ephemeral=True
                 )
                 return
+
+            user_info = await MatchmakingService.get_user_info(user.id)
 
             elo = user_info.get("elo")
             region = user_info.get("region")

--- a/cogs/voice_management/team_cog.py
+++ b/cogs/voice_management/team_cog.py
@@ -11,6 +11,7 @@ import datetime
 import asyncio
 
 from .services.five_stack_service import MatchmakingService
+from utils.checks import valorant_link_required
 
 # Constantes
 FORUM_CHANNEL_ID: int = 1325629700248178778  # ID réel de votre forum
@@ -114,6 +115,7 @@ class TeamManager(commands.Cog):
     # ------------------------------------------------
 
     @app_commands.command(name="create_team", description="Créer une équipe (même région que le leader).")
+    @valorant_link_required()
     @app_commands.describe(visibility="Définissez la visibilité de l'équipe.")
     @app_commands.choices(visibility=[
         app_commands.Choice(name="Public", value="public"),
@@ -194,6 +196,7 @@ class TeamManager(commands.Cog):
         )
 
     @app_commands.command(name="join_team", description="Rejoindre une équipe via son code.")
+    @valorant_link_required()
     async def join_team(self, interaction: discord.Interaction, code: str) -> None:
         """
         Permet à un utilisateur de rejoindre une équipe existante si celle-ci n'est pas complète.

--- a/cogs/voice_management/team_views.py
+++ b/cogs/voice_management/team_views.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any
 
 from cogs.voice_management.services.five_stack_service import MatchmakingService
+from cogs.ranking.services.assign_rank_service import valorant_account_linked
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +24,12 @@ class BaseLeaveTeamView(discord.ui.View):
 
     async def handle_leave_team(self, interaction: discord.Interaction) -> None:
         await interaction.response.defer(ephemeral=True)
+        if not await valorant_account_linked(interaction.user.id):
+            await interaction.followup.send(
+                content="Veuillez lier votre compte Valorant avant de rejoindre l'équipe.",
+                ephemeral=True,
+            )
+            return
 
         team = await MatchmakingService.get_team(self.code)
         if not team:
@@ -118,6 +125,12 @@ class TeamForumJoinButtonView(BaseLeaveTeamView):
         Si l'équipe atteint 5 membres, le salon vocal est créé.
         """
         await interaction.response.defer(ephemeral=True)
+        if not await valorant_account_linked(interaction.user.id):
+            await interaction.followup.send(
+                content="Veuillez lier votre compte Valorant avant de rejoindre l'équipe.",
+                ephemeral=True,
+            )
+            return
 
         team = await MatchmakingService.get_team(self.code)
         if not team:

--- a/utils/checks.py
+++ b/utils/checks.py
@@ -1,0 +1,84 @@
+import discord
+from discord.ext import commands
+from discord import app_commands
+from typing import Optional
+
+from cogs.rules.service.rules_services import has_accepted_rules, get_rules_channel_id
+from cogs.ranking.services.assign_rank_service import valorant_account_linked
+
+async def _send_rules_prompt(target, guild: discord.Guild, channel_id: Optional[int]):
+    if isinstance(target, discord.Interaction):
+        if channel_id:
+            link = f"https://discord.com/channels/{guild.id}/{channel_id}"
+            if not target.response.is_done():
+                await target.response.send_message(
+                    f"Veuillez accepter le règlement ici : {link}",
+                    ephemeral=True,
+                )
+            else:
+                await target.followup.send(
+                    f"Veuillez accepter le règlement ici : {link}",
+                    ephemeral=True,
+                )
+        else:
+            if not target.response.is_done():
+                await target.response.send_message(
+                    "Veuillez accepter le règlement avant d'utiliser cette commande.",
+                    ephemeral=True,
+                )
+            else:
+                await target.followup.send(
+                    "Veuillez accepter le règlement avant d'utiliser cette commande.",
+                    ephemeral=True,
+                )
+    else:  # commands.Context
+        if channel_id:
+            await target.send(
+                f"Veuillez accepter le règlement dans <#{channel_id}>.",
+                delete_after=10,
+            )
+        else:
+            await target.send(
+                "Veuillez accepter le règlement avant d'utiliser cette commande.",
+                delete_after=10,
+            )
+
+
+def rules_check():
+    async def predicate(ctx: commands.Context) -> bool:
+        if ctx.guild is None:
+            return True
+        if ctx.command and ctx.command.qualified_name == "setup_rules":
+            return True
+        if await has_accepted_rules(ctx.author.id):
+            return True
+        channel_id = await get_rules_channel_id(ctx.guild.id, ctx.guild.name)
+        await _send_rules_prompt(ctx, ctx.guild, channel_id)
+        return False
+    return commands.check(predicate)
+
+
+async def rules_interaction_check(interaction: discord.Interaction) -> bool:
+    if interaction.guild is None:
+        return True
+    if interaction.command and interaction.command.qualified_name == "setup_rules":
+        return True
+    if await has_accepted_rules(interaction.user.id):
+        return True
+    channel_id = await get_rules_channel_id(interaction.guild.id, interaction.guild.name)
+    await _send_rules_prompt(interaction, interaction.guild, channel_id)
+    return False
+
+
+def valorant_link_required():
+    async def predicate(interaction: discord.Interaction) -> bool:
+        if await valorant_account_linked(interaction.user.id):
+            return True
+        msg = "Vous devez lier votre compte Valorant avant d'utiliser cette commande."
+        if not interaction.response.is_done():
+            await interaction.response.send_message(msg, ephemeral=True)
+        else:
+            await interaction.followup.send(msg, ephemeral=True)
+        return False
+    return app_commands.check(predicate)
+


### PR DESCRIPTION
## Summary
- add DB check for Valorant link
- centralize rule and Valorant account verifications
- enforce rule acceptance for all commands
- require Valorant account link for MMR tracking and team creation/join
- handle rule and Valorant checks on scrims and queue interactions

## Testing
- `python -m py_compile bot.py cogs/ranking/mmr_tracker.py cogs/ranking/services/assign_rank_service.py cogs/voice_management/team_cog.py utils/checks.py cogs/voice_management/team_views.py cogs/voice_management/queue_views.py cogs/scrims/scrims.py`

------
https://chatgpt.com/codex/tasks/task_e_6841e41b2f8483289f99a2519bcf0316