### PR TITLE
Fix Valorant MMR history stats

### DIFF
--- a/cogs/ranking/mmr_tracker.py
+++ b/cogs/ranking/mmr_tracker.py
@@ -14,6 +14,32 @@ from cogs.ranking.services.mmr_stats_service import calculate_mmr_stats, parse_m
 logger = logging.getLogger(__name__)
 
 
+def _format_tracking_enabled_message(result) -> str:
+    if result.status == "imported":
+        return (
+            "✅ Suivi MMR activé. "
+            f"Historique importé ({result.inserted_count} entrées)."
+        )
+    if result.status == "already_present":
+        return "✅ Suivi MMR activé. L'historique de ce compte est déjà présent."
+    if result.status == "pending_sync":
+        return (
+            "✅ Suivi MMR activé. Synchronisation Valorant en cours ; "
+            "l'historique sera importé automatiquement ensuite."
+        )
+    if result.status == "empty":
+        return "✅ Suivi MMR activé. Aucun historique MMR disponible via l'API pour le moment."
+    if result.status == "rate_limited":
+        return (
+            "✅ Suivi MMR activé. L'API Valorant est rate-limitée ; "
+            "nouvel essai automatique plus tard."
+        )
+    return (
+        "✅ Suivi MMR activé. L'import de l'historique a échoué temporairement ; "
+        "nouvel essai automatique plus tard."
+    )
+
+
 async def _valorant_link_required(interaction: discord.Interaction) -> bool:
     linked = await interaction.client.ranking_service.account_linked(interaction.user.id)
     if not linked:
@@ -77,8 +103,11 @@ class MMRTracker(commands.Cog):
             await interaction.response.defer(thinking=True, ephemeral=True)
             if action.value == "activer":
                 await self._tracker_svc.enable_tracking(discord_id)
-                await self._tracker_svc.fetch_full_history(discord_id)
-                return await interaction.followup.send("✅ Suivi MMR activé.", ephemeral=True)
+                result = await self._tracker_svc.fetch_full_history(discord_id)
+                return await interaction.followup.send(
+                    _format_tracking_enabled_message(result),
+                    ephemeral=True,
+                )
             else:
                 await self._tracker_svc.disable_tracking(discord_id)
                 return await interaction.followup.send("⏸️ Suivi MMR désactivé.", ephemeral=True)

--- a/cogs/ranking/services/mmr_stats_service.py
+++ b/cogs/ranking/services/mmr_stats_service.py
@@ -15,6 +15,12 @@ class MmrHistoryRow(Protocol):
 
 
 @dataclass(frozen=True)
+class _DiffRow:
+    row: MmrHistoryRow
+    diff: int
+
+
+@dataclass(frozen=True)
 class MmrPeriodSelection:
     period: str
     season_num: int | None
@@ -65,10 +71,8 @@ def calculate_mmr_stats(
     if not period_rows:
         return None
 
-    if any(_row_attr(row, "match_id") for row in period_rows):
-        diffs, plot_rows = _metadata_diffs(history, start_date, require_match_id=True)
-    elif any(_row_attr(row, "rr_delta") is not None for row in period_rows):
-        diffs, plot_rows = _metadata_diffs(history, start_date, require_match_id=False)
+    if any(_row_attr(row, "rr_delta") is not None for row in period_rows):
+        diffs, plot_rows = _metadata_diffs(history, start_date)
     else:
         diffs, plot_rows = _legacy_diffs(history, start_date), period_rows
 
@@ -107,11 +111,8 @@ def _legacy_diffs(
 def _metadata_diffs(
     history: Sequence[MmrHistoryRow],
     start_date: date | None,
-    *,
-    require_match_id: bool,
 ) -> tuple[list[tuple[datetime, int]], list[MmrHistoryRow]]:
-    diffs: list[tuple[datetime, int]] = []
-    plot_rows: list[MmrHistoryRow] = []
+    diff_rows: list[_DiffRow] = []
     previous: MmrHistoryRow | None = None
 
     for row in history:
@@ -120,25 +121,82 @@ def _metadata_diffs(
             previous = row
             continue
 
-        match_id = _row_attr(row, "match_id")
-        if require_match_id and not match_id:
+        rr_delta = _row_attr(row, "rr_delta")
+        if previous is None and _row_attr(row, "source") == "legacy":
             previous = row
             continue
-
-        rr_delta = _row_attr(row, "rr_delta")
         if rr_delta is None and previous is not None:
             rr_delta = row.elo - previous.elo
         if rr_delta is None:
             previous = row
             continue
 
-        if require_match_id or rr_delta != 0:
-            diffs.append((row.recorded_at, rr_delta))
-            plot_rows.append(row)
+        if rr_delta != 0:
+            diff_rows.append(_DiffRow(row, rr_delta))
 
         previous = row
 
+    deduped_rows = _dedupe_imported_matches_and_snapshots(diff_rows)
+    diffs = [(item.row.recorded_at, item.diff) for item in deduped_rows]
+    plot_rows = _metadata_plot_rows(history, start_date, deduped_rows)
     return diffs, plot_rows
+
+
+def _dedupe_imported_matches_and_snapshots(diff_rows: list[_DiffRow]) -> list[_DiffRow]:
+    deduped: list[_DiffRow] = []
+    last_import: _DiffRow | None = None
+
+    for item in diff_rows:
+        if _row_attr(item.row, "match_id"):
+            deduped.append(item)
+            last_import = item
+            continue
+
+        if (
+            last_import
+            and item.row.elo == last_import.row.elo
+            and item.diff == last_import.diff
+        ):
+            continue
+
+        deduped.append(item)
+        last_import = None
+
+    return deduped
+
+
+def _metadata_plot_rows(
+    history: Sequence[MmrHistoryRow],
+    start_date: date | None,
+    diff_rows: list[_DiffRow],
+) -> list[MmrHistoryRow]:
+    if not diff_rows:
+        return []
+
+    selected_rows = [item.row for item in diff_rows]
+    first_change = selected_rows[0]
+    baseline = _find_plot_baseline(history, start_date, first_change)
+    if baseline is not None and baseline is not first_change:
+        return [baseline, *selected_rows]
+    return selected_rows
+
+
+def _find_plot_baseline(
+    history: Sequence[MmrHistoryRow],
+    start_date: date | None,
+    first_change: MmrHistoryRow,
+) -> MmrHistoryRow | None:
+    previous: MmrHistoryRow | None = None
+
+    for row in history:
+        if row is first_change:
+            if previous is not None:
+                return previous
+            return first_change
+        if not start_date or row.recorded_at.date() >= start_date:
+            previous = row
+
+    return first_change
 
 
 def _row_attr(row: MmrHistoryRow, name: str):

--- a/cogs/ranking/services/mmr_stats_service.py
+++ b/cogs/ranking/services/mmr_stats_service.py
@@ -152,11 +152,7 @@ def _dedupe_imported_matches_and_snapshots(diff_rows: list[_DiffRow]) -> list[_D
             last_import = item
             continue
 
-        if (
-            last_import
-            and item.row.elo == last_import.row.elo
-            and item.diff == last_import.diff
-        ):
+        if last_import and item.row.elo == last_import.row.elo:
             continue
 
         deduped.append(item)

--- a/cogs/ranking/services/mmr_stats_service.py
+++ b/cogs/ranking/services/mmr_stats_service.py
@@ -57,29 +57,22 @@ def calculate_mmr_stats(
     *,
     start_date: date | None,
 ) -> MmrStats | None:
-    diffs: list[tuple[datetime, int]] = []
-    for index in range(1, len(history)):
-        recorded_at = history[index].recorded_at
-        if start_date and recorded_at.date() < start_date:
-            continue
-
-        diff = history[index].elo - history[index - 1].elo
-        diffs.append((recorded_at, diff))
-
-    if not diffs:
+    period_rows = [
+        row
+        for row in history
+        if not start_date or row.recorded_at.date() >= start_date
+    ]
+    if not period_rows:
         return None
 
-    dates_plot = [
-        row.recorded_at
-        for row in history
-        if not start_date or row.recorded_at.date() >= start_date
-    ]
-    elos_plot = [
-        row.elo
-        for row in history
-        if not start_date or row.recorded_at.date() >= start_date
-    ]
-    if len(dates_plot) < 2:
+    if any(_row_attr(row, "match_id") for row in period_rows):
+        diffs, plot_rows = _metadata_diffs(history, start_date, require_match_id=True)
+    elif any(_row_attr(row, "rr_delta") is not None for row in period_rows):
+        diffs, plot_rows = _metadata_diffs(history, start_date, require_match_id=False)
+    else:
+        diffs, plot_rows = _legacy_diffs(history, start_date), period_rows
+
+    if not diffs or len(plot_rows) < 2:
         return None
 
     wins = [diff for _, diff in diffs if diff > 0]
@@ -91,6 +84,62 @@ def calculate_mmr_stats(
         avg_win=round(sum(wins) / len(wins)) if wins else 0,
         avg_loss=round(sum(losses) / len(losses)) if losses else 0,
         last_diff=diffs[-1][1],
-        dates_plot=dates_plot,
-        elos_plot=elos_plot,
+        dates_plot=[row.recorded_at for row in plot_rows],
+        elos_plot=[row.elo for row in plot_rows],
     )
+
+
+def _legacy_diffs(
+    history: Sequence[MmrHistoryRow],
+    start_date: date | None,
+) -> list[tuple[datetime, int]]:
+    diffs: list[tuple[datetime, int]] = []
+    for index in range(1, len(history)):
+        recorded_at = history[index].recorded_at
+        if start_date and recorded_at.date() < start_date:
+            continue
+
+        diff = history[index].elo - history[index - 1].elo
+        diffs.append((recorded_at, diff))
+    return diffs
+
+
+def _metadata_diffs(
+    history: Sequence[MmrHistoryRow],
+    start_date: date | None,
+    *,
+    require_match_id: bool,
+) -> tuple[list[tuple[datetime, int]], list[MmrHistoryRow]]:
+    diffs: list[tuple[datetime, int]] = []
+    plot_rows: list[MmrHistoryRow] = []
+    previous: MmrHistoryRow | None = None
+
+    for row in history:
+        in_period = not start_date or row.recorded_at.date() >= start_date
+        if not in_period:
+            previous = row
+            continue
+
+        match_id = _row_attr(row, "match_id")
+        if require_match_id and not match_id:
+            previous = row
+            continue
+
+        rr_delta = _row_attr(row, "rr_delta")
+        if rr_delta is None and previous is not None:
+            rr_delta = row.elo - previous.elo
+        if rr_delta is None:
+            previous = row
+            continue
+
+        if require_match_id or rr_delta != 0:
+            diffs.append((row.recorded_at, rr_delta))
+            plot_rows.append(row)
+
+        previous = row
+
+    return diffs, plot_rows
+
+
+def _row_attr(row: MmrHistoryRow, name: str):
+    return getattr(row, name, None)

--- a/cogs/ranking/services/mmr_stats_service.py
+++ b/cogs/ranking/services/mmr_stats_service.py
@@ -21,6 +21,12 @@ class _DiffRow:
 
 
 @dataclass(frozen=True)
+class _SyntheticPlotRow:
+    recorded_at: datetime
+    elo: int
+
+
+@dataclass(frozen=True)
 class MmrPeriodSelection:
     period: str
     season_num: int | None
@@ -174,6 +180,9 @@ def _metadata_plot_rows(
     baseline = _find_plot_baseline(history, start_date, first_change)
     if baseline is not None and baseline is not first_change:
         return [baseline, *selected_rows]
+    imported_baseline = _imported_plot_baseline(diff_rows[0])
+    if imported_baseline is not None:
+        return [imported_baseline, *selected_rows]
     return selected_rows
 
 
@@ -193,6 +202,15 @@ def _find_plot_baseline(
             previous = row
 
     return first_change
+
+
+def _imported_plot_baseline(diff_row: _DiffRow) -> _SyntheticPlotRow | None:
+    if not _row_attr(diff_row.row, "match_id"):
+        return None
+    return _SyntheticPlotRow(
+        recorded_at=diff_row.row.recorded_at - timedelta(seconds=1),
+        elo=diff_row.row.elo - diff_row.diff,
+    )
 
 
 def _row_attr(row: MmrHistoryRow, name: str):

--- a/cogs/ranking/services/mmr_stats_service.py
+++ b/cogs/ranking/services/mmr_stats_service.py
@@ -131,7 +131,7 @@ def _metadata_diffs(
             previous = row
             continue
 
-        if rr_delta != 0:
+        if rr_delta != 0 or _row_attr(row, "match_id"):
             diff_rows.append(_DiffRow(row, rr_delta))
 
         previous = row

--- a/cogs/ranking/services/mmr_tracker_service.py
+++ b/cogs/ranking/services/mmr_tracker_service.py
@@ -7,7 +7,8 @@ Aucun appel HTTP direct - delegue au HenrikDevService.
 
 import re
 import logging
-from datetime import datetime, timezone
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 
 from database.services.valorant_db_service import EloHistoryRow, ValorantDbService
@@ -15,6 +16,16 @@ from integrations.henrikdev.service import HenrikDevService
 from integrations.exceptions import RateLimitError
 
 logger = logging.getLogger(__name__)
+
+BACKFILL_RETRY_INTERVAL = timedelta(hours=6)
+
+
+@dataclass(frozen=True)
+class MmrHistoryBackfillResult:
+    status: str
+    inserted_count: int = 0
+    source: str | None = None
+    error: str | None = None
 
 
 class MmrTrackerService:
@@ -42,8 +53,10 @@ class MmrTrackerService:
 
     # ==================== history reads ====================
 
-    async def get_last_history_row(self, user_id: int) -> Optional[EloHistoryRow]:
-        return await self._valo_db.get_last_history_row(user_id)
+    async def get_last_history_row(
+        self, user_id: int, puuid: str | None = None
+    ) -> Optional[EloHistoryRow]:
+        return await self._valo_db.get_last_history_row(user_id, puuid)
 
     async def get_history(
         self, discord_id: int, season: int | None = None, act: int | None = None
@@ -62,50 +75,66 @@ class MmrTrackerService:
         Retourne True si une insertion a ete faite.
         """
         user_id = row["user_id"]
+        puuid = row.get("puuid")
+        region = row.get("region")
+        platform = row.get("platform")
         current_elo = row["elo"]
 
-        if current_elo is None or current_elo == 0:
-            return False
+        if puuid and region and platform:
+            await self._maybe_backfill_tracked_row(row)
 
-        last = await self.get_last_history_row(user_id)
-        prev_elo = last.elo if last else None
-        if prev_elo is not None and current_elo == prev_elo:
+        if not puuid or current_elo is None or current_elo == 0:
             return False
 
         season = row.get("current_season")
         act = row.get("current_act")
         if season is None or act is None:
-            partition = await self.get_latest_partition()
-            if partition is None:
-                logger.warning(
-                    f"[record_current_mmr_snapshot] Pas de partition disponible pour user_id={user_id}, skip"
-                )
-                return False
-            season, act = partition
+            logger.warning(
+                f"[record_current_mmr_snapshot] Donnees saison/acte incompletes pour user_id={user_id}, skip"
+            )
+            return False
 
-        rr = 0 if prev_elo is None else current_elo - prev_elo
+        last = await self.get_last_history_row(user_id, puuid)
+        prev_elo = last.elo if last else None
+        if prev_elo is not None and current_elo == prev_elo:
+            return False
+
+        rr_delta = 0 if prev_elo is None else current_elo - prev_elo
         entry = {
             "date": datetime.now(timezone.utc).isoformat(),
             "elo": current_elo,
-            "rr": rr,
+            "rr_delta": rr_delta,
             "season": {"short": f"e{season}a{act}"},
         }
-        await self.insert_history_entry(user_id, entry)
-        return True
+        return await self.insert_history_entry(
+            user_id, entry, puuid=puuid, source="tracker_snapshot"
+        )
 
     # ==================== history writes ====================
 
     async def insert_history_entry(
-        self, user_id: int, entry: dict[str, Any]
-    ) -> None:
+        self,
+        user_id: int,
+        entry: dict[str, Any],
+        *,
+        puuid: str | None = None,
+        source: str = "tracker_snapshot",
+    ) -> bool:
         """
         Parse une entree d'historique et l'insere en DB.
-        L'entree doit contenir: date, elo, rr, season.short.
+        L'entree doit contenir: date, elo, rr_delta/last_change, season.short.
         """
         raw_date = entry.get("date")
         elo = entry.get("elo")
-        rr = entry.get("rr", 0)
-        is_win = rr >= 0
+        rr_delta = entry.get("rr_delta", entry.get("last_change", entry.get("rr", 0)))
+        match_id = entry.get("match_id")
+        if rr_delta is None:
+            rr_delta = 0
+        is_win = rr_delta > 0
+
+        if elo is None:
+            logger.warning(f"[insert_history_entry] Pas d'elo pour user_id={user_id}")
+            return False
 
         season_info = entry.get("season") or {}
         season_short = season_info.get("short", "")
@@ -113,19 +142,19 @@ class MmrTrackerService:
             logger.warning(
                 f"[insert_history_entry] Pas de season.short pour user_id={user_id}. Ignore."
             )
-            return
+            return False
 
         m = re.match(r"e(\d+)a(\d+)", season_short)
         if not m:
             logger.warning(
                 f"[insert_history_entry] Format invalide: '{season_short}' pour user_id={user_id}. Ignore."
             )
-            return
+            return False
         season_num, act_num = map(int, m.groups())
 
         if not raw_date:
             logger.warning(f"[insert_history_entry] Pas de date pour user_id={user_id}")
-            return
+            return False
 
         if isinstance(raw_date, str):
             recorded_at = datetime.fromisoformat(raw_date.replace("Z", "+00:00"))
@@ -133,13 +162,22 @@ class MmrTrackerService:
             recorded_at = raw_date
 
         await self._valo_db.ensure_partitions(season_num, act_num)
-        await self._valo_db.insert_history_entry(
-            user_id, season_num, act_num, recorded_at, elo, is_win,
+        return await self._valo_db.insert_history_entry(
+            user_id,
+            season_num,
+            act_num,
+            recorded_at,
+            elo,
+            is_win,
+            puuid=puuid,
+            rr_delta=rr_delta,
+            match_id=match_id,
+            source=source,
         )
 
     # ==================== full history backfill ====================
 
-    async def fetch_full_history(self, discord_id: int) -> None:
+    async def fetch_full_history(self, discord_id: int) -> MmrHistoryBackfillResult:
         """
         Recupere l'historique complet MMR depuis l'API et l'insere en DB.
         Utilise stored-mmr-history (archivee) avec fallback sur mmr-history (live).
@@ -149,32 +187,78 @@ class MmrTrackerService:
         info = await self._valo_db.get_valorant_info_by_discord_id(discord_id)
         if not info:
             logger.warning(f"[fetch_full_history] Pas de valorant_info pour discord_id={discord_id}")
-            return
+            return MmrHistoryBackfillResult(status="pending_sync")
 
         if not info.puuid or not info.region or not info.platform:
             logger.warning(
                 f"[fetch_full_history] Donnees incompletes pour discord_id={discord_id}: "
                 f"puuid={info.puuid}, region={info.region}, platform={info.platform}"
             )
-            return
+            return MmrHistoryBackfillResult(status="pending_sync")
+
+        return await self._fetch_full_history_for_account(
+            user_id=info.user_id,
+            puuid=info.puuid,
+            region=info.region,
+            platform=info.platform,
+            backfilled_at=info.mmr_history_backfilled_at,
+        )
+
+    async def _maybe_backfill_tracked_row(
+        self, row: dict[str, Any]
+    ) -> MmrHistoryBackfillResult | None:
+        if row.get("mmr_history_backfilled_at") is not None:
+            return None
+
+        attempted_at = row.get("mmr_history_backfill_attempted_at")
+        if not self._backfill_retry_due(attempted_at):
+            return None
+
+        result = await self._fetch_full_history_for_account(
+            user_id=row["user_id"],
+            puuid=row["puuid"],
+            region=row["region"],
+            platform=row["platform"],
+            backfilled_at=None,
+        )
+        if result.status not in {"imported", "already_present"}:
+            logger.info(
+                "[_maybe_backfill_tracked_row] Backfill MMR non finalise pour user_id=%s: %s",
+                row["user_id"],
+                result.status,
+            )
+        return result
+
+    async def _fetch_full_history_for_account(
+        self,
+        *,
+        user_id: int,
+        puuid: str,
+        region: str,
+        platform: str,
+        backfilled_at: datetime | None,
+    ) -> MmrHistoryBackfillResult:
+        if backfilled_at is not None:
+            return MmrHistoryBackfillResult(status="already_present")
+
+        await self._valo_db.mark_mmr_history_backfill_attempt(user_id)
 
         # Tentative historique stocke
-        history_entries: list[dict] = []
+        history_entries: list[tuple[dict, str]] = []
         try:
             stored_resp, _ = await self._henrik.get_stored_mmr_history_by_puuid(
-                info.region, info.platform, info.puuid,
+                region, platform, puuid,
             )
             if stored_resp.status == 200 and stored_resp.data:
                 for entry in stored_resp.data:
-                    history_entries.append({
-                        "date": entry.date,
-                        "season": {"short": entry.season.short},
-                        "elo": entry.elo,
-                        "rr": entry.rr,
-                    })
+                    history_entries.append((
+                        self._history_entry_to_dict(entry),
+                        "henrik_stored",
+                    ))
         except RateLimitError:
             logger.error("[fetch_full_history] RateLimit sur stored history")
-            return
+            await self._valo_db.mark_mmr_history_backfill_attempt(user_id, "rate_limited")
+            return MmrHistoryBackfillResult(status="rate_limited", error="rate_limited")
         except Exception as e:
             logger.error(f"[fetch_full_history] Erreur stored history: {e}")
 
@@ -183,29 +267,67 @@ class MmrTrackerService:
             logger.info("[fetch_full_history] Pas d'historique stocke, fallback live")
             try:
                 live_resp, _ = await self._henrik.get_mmr_history_by_puuid(
-                    info.region, info.platform, info.puuid,
+                    region, platform, puuid,
                 )
                 if live_resp.status == 200 and live_resp.data.history:
                     for entry in live_resp.data.history:
-                        history_entries.append({
-                            "date": entry.date,
-                            "season": {"short": entry.season.short},
-                            "elo": entry.elo,
-                            "rr": entry.rr,
-                        })
+                        history_entries.append((
+                            self._history_entry_to_dict(entry),
+                            "henrik_live",
+                        ))
             except RateLimitError:
                 logger.error("[fetch_full_history] RateLimit sur live history")
-                return
+                await self._valo_db.mark_mmr_history_backfill_attempt(user_id, "rate_limited")
+                return MmrHistoryBackfillResult(status="rate_limited", error="rate_limited")
             except Exception as e:
                 logger.error(f"[fetch_full_history] Erreur live history: {e}")
-                return
+                error = self._short_error(e)
+                await self._valo_db.mark_mmr_history_backfill_attempt(user_id, error)
+                return MmrHistoryBackfillResult(status="error", error=error)
 
         if not history_entries:
-            logger.warning(f"[fetch_full_history] Aucun historique pour discord_id={discord_id}")
-            return
+            logger.warning(f"[fetch_full_history] Aucun historique pour user_id={user_id}")
+            await self._valo_db.mark_mmr_history_backfill_attempt(user_id, "empty")
+            return MmrHistoryBackfillResult(status="empty")
 
         logger.info(f"[fetch_full_history] Insertion de {len(history_entries)} entrees")
-        for entry in history_entries:
-            await self.insert_history_entry(info.user_id, entry)
+        inserted_count = 0
+        imported_source = history_entries[0][1]
+        for entry, source in history_entries:
+            inserted = await self.insert_history_entry(
+                user_id, entry, puuid=puuid, source=source
+            )
+            if inserted:
+                inserted_count += 1
 
-        logger.info(f"[fetch_full_history] Termine pour discord_id={discord_id}")
+        await self._valo_db.mark_mmr_history_backfilled(user_id)
+
+        logger.info(f"[fetch_full_history] Termine pour user_id={user_id}")
+        return MmrHistoryBackfillResult(
+            status="imported",
+            inserted_count=inserted_count,
+            source=imported_source,
+        )
+
+    @staticmethod
+    def _history_entry_to_dict(entry: Any) -> dict[str, Any]:
+        return {
+            "date": entry.date,
+            "season": {"short": entry.season.short},
+            "elo": entry.elo,
+            "rr_delta": entry.last_change,
+            "match_id": getattr(entry, "match_id", None),
+        }
+
+    @staticmethod
+    def _backfill_retry_due(attempted_at: datetime | None) -> bool:
+        if attempted_at is None:
+            return True
+        if attempted_at.tzinfo is None:
+            attempted_at = attempted_at.replace(tzinfo=timezone.utc)
+        return datetime.now(timezone.utc) - attempted_at >= BACKFILL_RETRY_INTERVAL
+
+    @staticmethod
+    def _short_error(exc: Exception) -> str:
+        message = str(exc) or exc.__class__.__name__
+        return message[:500]

--- a/cogs/ranking/services/mmr_tracker_service.py
+++ b/cogs/ranking/services/mmr_tracker_service.py
@@ -13,7 +13,7 @@ from typing import Any, Optional
 
 from database.services.valorant_db_service import EloHistoryRow, ValorantDbService
 from integrations.henrikdev.service import HenrikDevService
-from integrations.exceptions import RateLimitError
+from integrations.exceptions import ApiError, RateLimitError
 
 logger = logging.getLogger(__name__)
 
@@ -328,13 +328,19 @@ class MmrTrackerService:
 
         while page not in seen_pages:
             seen_pages.add(page)
-            stored_resp, _ = await self._henrik.get_stored_mmr_history_by_puuid(
-                region,
-                platform,
-                puuid,
-                page=page,
-                size=size,
-            )
+            try:
+                stored_resp, _ = await self._henrik.get_stored_mmr_history_by_puuid(
+                    region,
+                    platform,
+                    puuid,
+                    page=page,
+                    size=size,
+                )
+            except ApiError as exc:
+                if not entries and page is None and self._is_missing_stored_history(exc):
+                    logger.info("[fetch_full_history] Historique stocke absent")
+                    return []
+                raise
             if stored_resp.status != 200:
                 if entries:
                     raise RuntimeError(
@@ -390,3 +396,7 @@ class MmrTrackerService:
     def _short_error(exc: Exception) -> str:
         message = str(exc) or exc.__class__.__name__
         return message[:500]
+
+    @staticmethod
+    def _is_missing_stored_history(exc: Exception) -> bool:
+        return isinstance(exc, ApiError) and str(exc).startswith("HTTP 404:")

--- a/cogs/ranking/services/mmr_tracker_service.py
+++ b/cogs/ranking/services/mmr_tracker_service.py
@@ -264,6 +264,9 @@ class MmrTrackerService:
             return MmrHistoryBackfillResult(status="rate_limited", error="rate_limited")
         except Exception as e:
             logger.error(f"[fetch_full_history] Erreur stored history: {e}")
+            error = self._short_error(e)
+            await self._valo_db.mark_mmr_history_backfill_attempt(user_id, error)
+            return MmrHistoryBackfillResult(status="error", error=error)
 
         # Fallback sur live history si vide
         if not history_entries:

--- a/cogs/ranking/services/mmr_tracker_service.py
+++ b/cogs/ranking/services/mmr_tracker_service.py
@@ -89,10 +89,13 @@ class MmrTrackerService:
         season = row.get("current_season")
         act = row.get("current_act")
         if season is None or act is None:
-            logger.warning(
-                f"[record_current_mmr_snapshot] Donnees saison/acte incompletes pour user_id={user_id}, skip"
-            )
-            return False
+            latest_partition = await self.get_latest_partition()
+            if latest_partition is None:
+                logger.warning(
+                    f"[record_current_mmr_snapshot] Donnees saison/acte incompletes pour user_id={user_id}, skip"
+                )
+                return False
+            season, act = latest_partition
 
         last = await self.get_last_history_row(user_id, puuid)
         prev_elo = last.elo if last else None

--- a/cogs/ranking/services/mmr_tracker_service.py
+++ b/cogs/ranking/services/mmr_tracker_service.py
@@ -319,17 +319,17 @@ class MmrTrackerService:
         puuid: str,
     ) -> list[Any]:
         entries: list[Any] = []
-        start: int | None = None
+        page: int | None = None
         size: int | None = None
-        seen_starts: set[int | None] = set()
+        seen_pages: set[int | None] = set()
 
-        while start not in seen_starts:
-            seen_starts.add(start)
+        while page not in seen_pages:
+            seen_pages.add(page)
             stored_resp, _ = await self._henrik.get_stored_mmr_history_by_puuid(
                 region,
                 platform,
                 puuid,
-                start=start,
+                page=page,
                 size=size,
             )
             if stored_resp.status != 200:
@@ -340,12 +340,12 @@ class MmrTrackerService:
                 break
             entries.extend(stored_resp.data or [])
 
-            next_start, next_size = self._next_stored_history_page(stored_resp)
-            if next_start is None:
+            next_page, next_size = self._next_stored_history_page(stored_resp)
+            if next_page is None:
                 break
-            if next_start in seen_starts:
+            if next_page in seen_pages:
                 raise RuntimeError("stored mmr history pagination did not advance")
-            start = next_start
+            page = next_page
             size = next_size
 
         return entries
@@ -362,7 +362,8 @@ class MmrTrackerService:
             return None, None
 
         before = getattr(results, "before", 0) or 0
-        return before + returned, returned
+        current_page = before // returned + 1
+        return current_page + 1, returned
 
     @staticmethod
     def _history_entry_to_dict(entry: Any) -> dict[str, Any]:

--- a/cogs/ranking/services/mmr_tracker_service.py
+++ b/cogs/ranking/services/mmr_tracker_service.py
@@ -249,11 +249,11 @@ class MmrTrackerService:
         # Tentative historique stocke
         history_entries: list[tuple[dict, str]] = []
         try:
-            stored_resp, _ = await self._henrik.get_stored_mmr_history_by_puuid(
+            stored_entries = await self._fetch_stored_mmr_history_pages(
                 region, platform, puuid,
             )
-            if stored_resp.status == 200 and stored_resp.data:
-                for entry in stored_resp.data:
+            if stored_entries:
+                for entry in stored_entries:
                     history_entries.append((
                         self._history_entry_to_dict(entry),
                         "henrik_stored",
@@ -311,6 +311,58 @@ class MmrTrackerService:
             inserted_count=inserted_count,
             source=imported_source,
         )
+
+    async def _fetch_stored_mmr_history_pages(
+        self,
+        region: str,
+        platform: str,
+        puuid: str,
+    ) -> list[Any]:
+        entries: list[Any] = []
+        start: int | None = None
+        size: int | None = None
+        seen_starts: set[int | None] = set()
+
+        while start not in seen_starts:
+            seen_starts.add(start)
+            stored_resp, _ = await self._henrik.get_stored_mmr_history_by_puuid(
+                region,
+                platform,
+                puuid,
+                start=start,
+                size=size,
+            )
+            if stored_resp.status != 200:
+                if entries:
+                    raise RuntimeError(
+                        f"stored mmr history page failed with status {stored_resp.status}"
+                    )
+                break
+            entries.extend(stored_resp.data or [])
+
+            next_start, next_size = self._next_stored_history_page(stored_resp)
+            if next_start is None:
+                break
+            if next_start in seen_starts:
+                raise RuntimeError("stored mmr history pagination did not advance")
+            start = next_start
+            size = next_size
+
+        return entries
+
+    @staticmethod
+    def _next_stored_history_page(stored_resp: Any) -> tuple[int | None, int | None]:
+        results = getattr(stored_resp, "results", None)
+        if results is None:
+            return None, None
+
+        returned = getattr(results, "returned", 0) or 0
+        after = getattr(results, "after", 0) or 0
+        if returned <= 0 or after <= 0:
+            return None, None
+
+        before = getattr(results, "before", 0) or 0
+        return before + returned, returned
 
     @staticmethod
     def _history_entry_to_dict(entry: Any) -> dict[str, Any]:

--- a/database/migrations/029_mmr_history_metadata.sql
+++ b/database/migrations/029_mmr_history_metadata.sql
@@ -12,12 +12,9 @@ ALTER TABLE IF EXISTS valorant_info
   ADD COLUMN IF NOT EXISTS mmr_history_backfill_attempted_at TIMESTAMPTZ,
   ADD COLUMN IF NOT EXISTS mmr_history_backfill_error TEXT;
 
-UPDATE valorant_elo_history_parent h
-   SET puuid = vi.puuid
-  FROM valorant_info vi
- WHERE h.user_id = vi.user_id
-   AND h.puuid IS NULL
-   AND vi.puuid IS NOT NULL;
+-- Legacy history rows stay unscoped when their PUUID was not known at write time.
+-- Stamping all old rows with the currently linked PUUID would permanently attach
+-- previous-account history to the current account for users who changed accounts.
 
 WITH history_diffs AS (
   SELECT

--- a/database/migrations/029_mmr_history_metadata.sql
+++ b/database/migrations/029_mmr_history_metadata.sql
@@ -1,0 +1,49 @@
+-- 029_mmr_history_metadata.sql
+-- Add account-scoped MMR history metadata without removing legacy data.
+
+ALTER TABLE IF EXISTS valorant_elo_history_parent
+  ADD COLUMN IF NOT EXISTS puuid VARCHAR(255),
+  ADD COLUMN IF NOT EXISTS rr_delta INTEGER,
+  ADD COLUMN IF NOT EXISTS match_id VARCHAR(128),
+  ADD COLUMN IF NOT EXISTS source VARCHAR(32) NOT NULL DEFAULT 'legacy';
+
+ALTER TABLE IF EXISTS valorant_info
+  ADD COLUMN IF NOT EXISTS mmr_history_backfilled_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS mmr_history_backfill_attempted_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS mmr_history_backfill_error TEXT;
+
+UPDATE valorant_elo_history_parent h
+   SET puuid = vi.puuid
+  FROM valorant_info vi
+ WHERE h.user_id = vi.user_id
+   AND h.puuid IS NULL
+   AND vi.puuid IS NOT NULL;
+
+WITH history_diffs AS (
+  SELECT
+    season,
+    act,
+    user_id,
+    recorded_at,
+    elo - LAG(elo) OVER (
+      PARTITION BY user_id
+      ORDER BY recorded_at, season, act
+    ) AS computed_rr_delta
+  FROM valorant_elo_history_parent
+)
+UPDATE valorant_elo_history_parent h
+   SET rr_delta = d.computed_rr_delta
+  FROM history_diffs d
+ WHERE h.season = d.season
+   AND h.act = d.act
+   AND h.user_id = d.user_id
+   AND h.recorded_at = d.recorded_at
+   AND h.rr_delta IS NULL
+   AND d.computed_rr_delta IS NOT NULL;
+
+UPDATE valorant_elo_history_parent
+   SET source = 'legacy'
+ WHERE source IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_valorant_elo_history_user_puuid_recorded_at
+  ON valorant_elo_history_parent (user_id, puuid, recorded_at DESC);

--- a/database/migrations/README.md
+++ b/database/migrations/README.md
@@ -40,6 +40,11 @@ Complex domain backfills are split by responsibility:
 - `028_five_stack_v2_backfill.sql` backfills teams, queue entries, queue roles,
   matches, participants, participant roles, feedback, and player stats.
 
+`029_mmr_history_metadata.sql` enriches the active Valorant MMR history with
+account-scoped metadata (`puuid`, RR delta, match id, source) and backfill
+status fields on `valorant_info`. It is additive and keeps the runtime on the
+current Valorant tables.
+
 After these migrations are committed, a live schema audit will report drift until
 the pending v2 migrations have been applied to the target database. Run a
 `pg_dump` backup before applying them on production.

--- a/database/repos/valorant_elo_history_repo.py
+++ b/database/repos/valorant_elo_history_repo.py
@@ -67,7 +67,10 @@ class ValorantEloHistoryRepo:
             params += [season, act]
 
         if puuid is not None:
-            sql += f" AND puuid = ${len(params) + 1}"
+            sql += (
+                f" AND (puuid = ${len(params) + 1} "
+                "OR (puuid IS NULL AND source = 'legacy'))"
+            )
             params.append(puuid)
 
         sql += " ORDER BY recorded_at;"
@@ -103,7 +106,7 @@ class ValorantEloHistoryRepo:
         )
         params: list = [user_id]
         if puuid is not None:
-            sql += " AND puuid = $2"
+            sql += " AND (puuid = $2 OR (puuid IS NULL AND source = 'legacy'))"
             params.append(puuid)
         sql += " ORDER BY season DESC, act DESC;"
         rows = await conn.fetch(sql, *params)

--- a/database/repos/valorant_elo_history_repo.py
+++ b/database/repos/valorant_elo_history_repo.py
@@ -14,6 +14,10 @@ class EloHistoryRow:
     recorded_at: datetime
     elo: int
     is_win: bool
+    puuid: str | None
+    rr_delta: int | None
+    match_id: str | None
+    source: str
 
 
 def _row_to_model(row: asyncpg.Record) -> EloHistoryRow:
@@ -24,6 +28,10 @@ def _row_to_model(row: asyncpg.Record) -> EloHistoryRow:
         recorded_at=row["recorded_at"],
         elo=row["elo"],
         is_win=row["is_win"],
+        puuid=row["puuid"],
+        rr_delta=row["rr_delta"],
+        match_id=row["match_id"],
+        source=row["source"],
     )
 
 
@@ -44,17 +52,23 @@ class ValorantEloHistoryRepo:
         user_id: int,
         season: int | None = None,
         act: int | None = None,
+        puuid: str | None = None,
     ) -> list[EloHistoryRow]:
         sql = (
-            "SELECT season, act, user_id, recorded_at, elo, is_win "
+            "SELECT season, act, user_id, recorded_at, elo, is_win, "
+            "       puuid, rr_delta, match_id, source "
             "  FROM valorant_elo_history_parent "
             " WHERE user_id = $1"
         )
         params: list = [user_id]
 
         if season is not None and act is not None:
-            sql += " AND season = $2 AND act = $3"
+            sql += f" AND season = ${len(params) + 1} AND act = ${len(params) + 2}"
             params += [season, act]
+
+        if puuid is not None:
+            sql += f" AND puuid = ${len(params) + 1}"
+            params.append(puuid)
 
         sql += " ORDER BY recorded_at;"
         rows = await conn.fetch(sql, *params)
@@ -62,33 +76,37 @@ class ValorantEloHistoryRepo:
 
     @staticmethod
     async def get_last_row(
-        conn: asyncpg.Connection, user_id: int
+        conn: asyncpg.Connection, user_id: int, puuid: str | None = None
     ) -> Optional[EloHistoryRow]:
-        row = await conn.fetchrow(
-            """
-            SELECT season, act, user_id, recorded_at, elo, is_win
-              FROM valorant_elo_history_parent
-             WHERE user_id = $1
-             ORDER BY recorded_at DESC
-             LIMIT 1;
-            """,
-            user_id,
+        sql = (
+            "SELECT season, act, user_id, recorded_at, elo, is_win, "
+            "       puuid, rr_delta, match_id, source "
+            "  FROM valorant_elo_history_parent "
+            " WHERE user_id = $1"
         )
+        params: list = [user_id]
+        if puuid is not None:
+            sql += " AND puuid = $2"
+            params.append(puuid)
+        sql += " ORDER BY recorded_at DESC LIMIT 1;"
+        row = await conn.fetchrow(sql, *params)
         return _row_to_model(row) if row else None
 
     @staticmethod
     async def get_distinct_partitions(
-        conn: asyncpg.Connection, user_id: int
+        conn: asyncpg.Connection, user_id: int, puuid: str | None = None
     ) -> list[tuple[int, int]]:
-        rows = await conn.fetch(
-            """
-            SELECT DISTINCT season, act
-              FROM valorant_elo_history_parent
-             WHERE user_id = $1
-             ORDER BY season DESC, act DESC;
-            """,
-            user_id,
+        sql = (
+            "SELECT DISTINCT season, act "
+            "  FROM valorant_elo_history_parent "
+            " WHERE user_id = $1"
         )
+        params: list = [user_id]
+        if puuid is not None:
+            sql += " AND puuid = $2"
+            params.append(puuid)
+        sql += " ORDER BY season DESC, act DESC;"
+        rows = await conn.fetch(sql, *params)
         return [(r["season"], r["act"]) for r in rows]
 
     @staticmethod
@@ -139,13 +157,38 @@ class ValorantEloHistoryRepo:
         recorded_at: datetime,
         elo: int,
         is_win: bool,
-    ) -> None:
-        await conn.execute(
+        puuid: str | None = None,
+        rr_delta: int | None = None,
+        match_id: str | None = None,
+        source: str = "tracker_snapshot",
+    ) -> bool:
+        result = await conn.execute(
             """
             INSERT INTO valorant_elo_history_parent
-                   (season, act, user_id, recorded_at, elo, is_win)
-            VALUES ($1, $2, $3, $4, $5, $6)
-            ON CONFLICT (season, act, user_id, recorded_at) DO NOTHING;
+                   (season, act, user_id, recorded_at, elo, is_win,
+                    puuid, rr_delta, match_id, source)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            ON CONFLICT (season, act, user_id, recorded_at)
+            DO UPDATE SET
+                puuid = COALESCE(valorant_elo_history_parent.puuid, EXCLUDED.puuid),
+                rr_delta = COALESCE(valorant_elo_history_parent.rr_delta, EXCLUDED.rr_delta),
+                match_id = COALESCE(valorant_elo_history_parent.match_id, EXCLUDED.match_id),
+                source = CASE
+                    WHEN valorant_elo_history_parent.source = 'legacy'
+                         AND EXCLUDED.source <> 'legacy'
+                    THEN EXCLUDED.source
+                    ELSE valorant_elo_history_parent.source
+                END;
             """,
-            season, act, user_id, recorded_at, elo, is_win,
+            season,
+            act,
+            user_id,
+            recorded_at,
+            elo,
+            is_win,
+            puuid,
+            rr_delta,
+            match_id,
+            source,
         )
+        return result != "INSERT 0 0"

--- a/database/repos/valorant_elo_history_repo.py
+++ b/database/repos/valorant_elo_history_repo.py
@@ -53,6 +53,7 @@ class ValorantEloHistoryRepo:
         season: int | None = None,
         act: int | None = None,
         puuid: str | None = None,
+        legacy_only: bool = False,
     ) -> list[EloHistoryRow]:
         sql = (
             "SELECT season, act, user_id, recorded_at, elo, is_win, "
@@ -67,11 +68,10 @@ class ValorantEloHistoryRepo:
             params += [season, act]
 
         if puuid is not None:
-            sql += (
-                f" AND (puuid = ${len(params) + 1} "
-                "OR (puuid IS NULL AND source = 'legacy'))"
-            )
+            sql += f" AND puuid = ${len(params) + 1}"
             params.append(puuid)
+        elif legacy_only:
+            sql += " AND puuid IS NULL AND source = 'legacy'"
 
         sql += " ORDER BY recorded_at;"
         rows = await conn.fetch(sql, *params)
@@ -79,7 +79,10 @@ class ValorantEloHistoryRepo:
 
     @staticmethod
     async def get_last_row(
-        conn: asyncpg.Connection, user_id: int, puuid: str | None = None
+        conn: asyncpg.Connection,
+        user_id: int,
+        puuid: str | None = None,
+        legacy_only: bool = False,
     ) -> Optional[EloHistoryRow]:
         sql = (
             "SELECT season, act, user_id, recorded_at, elo, is_win, "
@@ -89,15 +92,20 @@ class ValorantEloHistoryRepo:
         )
         params: list = [user_id]
         if puuid is not None:
-            sql += " AND (puuid = $2 OR (puuid IS NULL AND source = 'legacy'))"
+            sql += " AND puuid = $2"
             params.append(puuid)
+        elif legacy_only:
+            sql += " AND puuid IS NULL AND source = 'legacy'"
         sql += " ORDER BY recorded_at DESC LIMIT 1;"
         row = await conn.fetchrow(sql, *params)
         return _row_to_model(row) if row else None
 
     @staticmethod
     async def get_distinct_partitions(
-        conn: asyncpg.Connection, user_id: int, puuid: str | None = None
+        conn: asyncpg.Connection,
+        user_id: int,
+        puuid: str | None = None,
+        legacy_only: bool = False,
     ) -> list[tuple[int, int]]:
         sql = (
             "SELECT DISTINCT season, act "
@@ -106,8 +114,10 @@ class ValorantEloHistoryRepo:
         )
         params: list = [user_id]
         if puuid is not None:
-            sql += " AND (puuid = $2 OR (puuid IS NULL AND source = 'legacy'))"
+            sql += " AND puuid = $2"
             params.append(puuid)
+        elif legacy_only:
+            sql += " AND puuid IS NULL AND source = 'legacy'"
         sql += " ORDER BY season DESC, act DESC;"
         rows = await conn.fetch(sql, *params)
         return [(r["season"], r["act"]) for r in rows]

--- a/database/repos/valorant_elo_history_repo.py
+++ b/database/repos/valorant_elo_history_repo.py
@@ -89,7 +89,7 @@ class ValorantEloHistoryRepo:
         )
         params: list = [user_id]
         if puuid is not None:
-            sql += " AND puuid = $2"
+            sql += " AND (puuid = $2 OR (puuid IS NULL AND source = 'legacy'))"
             params.append(puuid)
         sql += " ORDER BY recorded_at DESC LIMIT 1;"
         row = await conn.fetchrow(sql, *params)

--- a/database/repos/valorant_info_repo.py
+++ b/database/repos/valorant_info_repo.py
@@ -25,6 +25,9 @@ class ValorantInfoRow:
     last_checked_at: datetime | None
     last_notification: datetime | None
     deactivated_at: datetime | None
+    mmr_history_backfilled_at: datetime | None
+    mmr_history_backfill_attempted_at: datetime | None
+    mmr_history_backfill_error: str | None
 
 
 @dataclass(frozen=True)
@@ -52,6 +55,9 @@ def _row_to_model(row: asyncpg.Record) -> ValorantInfoRow:
         last_checked_at=row["last_checked_at"],
         last_notification=row["last_notification"],
         deactivated_at=row["deactivated_at"],
+        mmr_history_backfilled_at=row["mmr_history_backfilled_at"],
+        mmr_history_backfill_attempted_at=row["mmr_history_backfill_attempted_at"],
+        mmr_history_backfill_error=row["mmr_history_backfill_error"],
     )
 
 
@@ -68,7 +74,10 @@ class ValorantInfoRepo:
             SELECT user_id, pseudo, tag, puuid, region, platform, rank, elo,
                    current_season, current_act, is_active, tracking_enabled,
                    error_count, last_error_at, last_checked_at,
-                   last_notification, deactivated_at
+                   last_notification, deactivated_at,
+                   mmr_history_backfilled_at,
+                   mmr_history_backfill_attempted_at,
+                   mmr_history_backfill_error
               FROM valorant_info
              WHERE user_id = $1;
             """,
@@ -85,7 +94,10 @@ class ValorantInfoRepo:
             SELECT user_id, pseudo, tag, puuid, region, platform, rank, elo,
                    current_season, current_act, is_active, tracking_enabled,
                    error_count, last_error_at, last_checked_at,
-                   last_notification, deactivated_at
+                   last_notification, deactivated_at,
+                   mmr_history_backfilled_at,
+                   mmr_history_backfill_attempted_at,
+                   mmr_history_backfill_error
               FROM valorant_info
              WHERE pseudo = $1
                AND tag = $2
@@ -120,7 +132,10 @@ class ValorantInfoRepo:
             SELECT user_id, pseudo, tag, puuid, region, platform, rank, elo,
                    current_season, current_act, is_active, tracking_enabled,
                    error_count, last_error_at, last_checked_at,
-                   last_notification, deactivated_at
+                   last_notification, deactivated_at,
+                   mmr_history_backfilled_at,
+                   mmr_history_backfill_attempted_at,
+                   mmr_history_backfill_error
               FROM valorant_info
              WHERE is_active = TRUE
                AND pseudo IS NOT NULL
@@ -145,7 +160,10 @@ class ValorantInfoRepo:
             SELECT user_id, pseudo, tag, puuid, region, platform, rank, elo,
                    current_season, current_act, is_active, tracking_enabled,
                    error_count, last_error_at, last_checked_at,
-                   last_notification, deactivated_at
+                   last_notification, deactivated_at,
+                   mmr_history_backfilled_at,
+                   mmr_history_backfill_attempted_at,
+                   mmr_history_backfill_error
               FROM valorant_info
              WHERE pseudo IS NOT NULL
                AND tag    IS NOT NULL;
@@ -162,9 +180,13 @@ class ValorantInfoRepo:
             SELECT user_id, pseudo, tag, puuid, region, platform, rank, elo,
                    current_season, current_act, is_active, tracking_enabled,
                    error_count, last_error_at, last_checked_at,
-                   last_notification, deactivated_at
+                   last_notification, deactivated_at,
+                   mmr_history_backfilled_at,
+                   mmr_history_backfill_attempted_at,
+                   mmr_history_backfill_error
               FROM valorant_info
-             WHERE tracking_enabled = TRUE;
+             WHERE tracking_enabled = TRUE
+               AND is_active = TRUE;
             """
         )
         return [_row_to_model(r) for r in rows]
@@ -225,7 +247,10 @@ class ValorantInfoRepo:
                           error_count    = 0,
                           last_error_at  = NULL,
                           last_checked_at = NULL,
-                          last_notification = NULL;
+                          last_notification = NULL,
+                          mmr_history_backfilled_at = NULL,
+                          mmr_history_backfill_attempted_at = NULL,
+                          mmr_history_backfill_error = NULL;
             """,
             user_id, pseudo, tag,
         )
@@ -308,7 +333,10 @@ class ValorantInfoRepo:
                    error_count = 0,
                    last_error_at = NULL,
                    last_checked_at = NULL,
-                   last_notification = NULL
+                   last_notification = NULL,
+                   mmr_history_backfilled_at = NULL,
+                   mmr_history_backfill_attempted_at = NULL,
+                   mmr_history_backfill_error = NULL
              WHERE user_id = $3;
             """,
             pseudo, tag, user_id,
@@ -475,6 +503,36 @@ class ValorantInfoRepo:
         await conn.execute(
             "UPDATE valorant_info SET last_notification = $1 WHERE user_id = $2;",
             ts, user_id,
+        )
+
+    @staticmethod
+    async def mark_mmr_history_backfill_attempt(
+        conn: asyncpg.Connection, user_id: int, error: str | None = None
+    ) -> None:
+        await conn.execute(
+            """
+            UPDATE valorant_info
+               SET mmr_history_backfill_attempted_at = NOW(),
+                   mmr_history_backfill_error = $1
+             WHERE user_id = $2;
+            """,
+            error,
+            user_id,
+        )
+
+    @staticmethod
+    async def mark_mmr_history_backfilled(
+        conn: asyncpg.Connection, user_id: int
+    ) -> None:
+        await conn.execute(
+            """
+            UPDATE valorant_info
+               SET mmr_history_backfilled_at = NOW(),
+                   mmr_history_backfill_attempted_at = NOW(),
+                   mmr_history_backfill_error = NULL
+             WHERE user_id = $1;
+            """,
+            user_id,
         )
 
     @staticmethod

--- a/database/schema_contract.py
+++ b/database/schema_contract.py
@@ -439,9 +439,25 @@ EXPECTED_COLUMNS: Mapping[str, frozenset[str]] = {
             "last_checked_at",
             "last_notification",
             "deactivated_at",
+            "mmr_history_backfilled_at",
+            "mmr_history_backfill_attempted_at",
+            "mmr_history_backfill_error",
         }
     ),
-    "valorant_elo_history_parent": frozenset({"season", "act", "user_id", "recorded_at", "elo", "is_win"}),
+    "valorant_elo_history_parent": frozenset(
+        {
+            "season",
+            "act",
+            "user_id",
+            "recorded_at",
+            "elo",
+            "is_win",
+            "puuid",
+            "rr_delta",
+            "match_id",
+            "source",
+        }
+    ),
     "valorant_sent_bundles": frozenset({"guild_id", "bundle_uuid", "notified_at"}),
 }
 
@@ -734,6 +750,7 @@ EXPECTED_INDEXES = frozenset(
         "idx_valorant_info_tracking",
         "idx_valorant_info_pseudo_tag",
         "idx_valorant_info_puuid",
+        "idx_valorant_elo_history_user_puuid_recorded_at",
         "idx_valorant_sent_bundles_guild_id",
     }
 )

--- a/database/services/valorant_db_service.py
+++ b/database/services/valorant_db_service.py
@@ -249,8 +249,12 @@ class ValorantDbService:
             if user_id is None:
                 return []
             info = await ValorantInfoRepo.get_by_user_id(conn, user_id)
-            if info is None or not info.puuid:
+            if info is None:
                 return []
+            if not info.puuid:
+                return await ValorantEloHistoryRepo.get_history(
+                    conn, user_id, season, act, legacy_only=True
+                )
             return await ValorantEloHistoryRepo.get_history(
                 conn, user_id, season, act, info.puuid
             )
@@ -261,8 +265,12 @@ class ValorantDbService:
             if user_id is None:
                 return []
             info = await ValorantInfoRepo.get_by_user_id(conn, user_id)
-            if info is None or not info.puuid:
+            if info is None:
                 return []
+            if not info.puuid:
+                return await ValorantEloHistoryRepo.get_distinct_partitions(
+                    conn, user_id, legacy_only=True
+                )
             return await ValorantEloHistoryRepo.get_distinct_partitions(
                 conn, user_id, info.puuid
             )

--- a/database/services/valorant_db_service.py
+++ b/database/services/valorant_db_service.py
@@ -217,22 +217,29 @@ class ValorantDbService:
             await ValorantInfoRepo.disable_tracking(conn, user_id)
 
     async def get_tracked_players(self) -> list[dict]:
-        """Retourne user_id, elo, current_season, current_act pour chaque joueur suivi."""
+        """Retourne les infos necessaires au suivi MMR pour chaque joueur actif suivi."""
         async with self._db.acquire() as conn:
             rows = await ValorantInfoRepo.get_tracked(conn)
             return [
                 {
                     "user_id": r.user_id,
+                    "puuid": r.puuid,
+                    "region": r.region,
+                    "platform": r.platform,
                     "elo": r.elo,
                     "current_season": r.current_season,
                     "current_act": r.current_act,
+                    "mmr_history_backfilled_at": r.mmr_history_backfilled_at,
+                    "mmr_history_backfill_attempted_at": r.mmr_history_backfill_attempted_at,
                 }
                 for r in rows
             ]
 
-    async def get_last_history_row(self, user_id: int) -> Optional[EloHistoryRow]:
+    async def get_last_history_row(
+        self, user_id: int, puuid: str | None = None
+    ) -> Optional[EloHistoryRow]:
         async with self._db.acquire() as conn:
-            return await ValorantEloHistoryRepo.get_last_row(conn, user_id)
+            return await ValorantEloHistoryRepo.get_last_row(conn, user_id, puuid)
 
     async def get_history(
         self, discord_id: int, season: int | None = None, act: int | None = None
@@ -241,14 +248,24 @@ class ValorantDbService:
             user_id = await self._resolve_user_id(conn, discord_id)
             if user_id is None:
                 return []
-            return await ValorantEloHistoryRepo.get_history(conn, user_id, season, act)
+            info = await ValorantInfoRepo.get_by_user_id(conn, user_id)
+            if info is None or not info.puuid:
+                return []
+            return await ValorantEloHistoryRepo.get_history(
+                conn, user_id, season, act, info.puuid
+            )
 
     async def get_partitions(self, discord_id: int) -> list[tuple[int, int]]:
         async with self._db.acquire() as conn:
             user_id = await self._resolve_user_id(conn, discord_id)
             if user_id is None:
                 return []
-            return await ValorantEloHistoryRepo.get_distinct_partitions(conn, user_id)
+            info = await ValorantInfoRepo.get_by_user_id(conn, user_id)
+            if info is None or not info.puuid:
+                return []
+            return await ValorantEloHistoryRepo.get_distinct_partitions(
+                conn, user_id, info.puuid
+            )
 
     async def get_latest_partition(self) -> Optional[tuple[int, int]]:
         async with self._db.acquire() as conn:
@@ -266,10 +283,24 @@ class ValorantDbService:
         recorded_at: datetime,
         elo: int,
         is_win: bool,
-    ) -> None:
+        puuid: str | None = None,
+        rr_delta: int | None = None,
+        match_id: str | None = None,
+        source: str = "tracker_snapshot",
+    ) -> bool:
         async with self._db.transaction() as conn:
-            await ValorantEloHistoryRepo.insert_entry(
-                conn, season, act, user_id, recorded_at, elo, is_win,
+            return await ValorantEloHistoryRepo.insert_entry(
+                conn,
+                season,
+                act,
+                user_id,
+                recorded_at,
+                elo,
+                is_win,
+                puuid=puuid,
+                rr_delta=rr_delta,
+                match_id=match_id,
+                source=source,
             )
 
     async def get_valorant_info_by_user_id(
@@ -286,6 +317,16 @@ class ValorantDbService:
             if user_id is None:
                 return None
             return await ValorantInfoRepo.get_by_user_id(conn, user_id)
+
+    async def mark_mmr_history_backfill_attempt(
+        self, user_id: int, error: str | None = None
+    ) -> None:
+        async with self._db.transaction() as conn:
+            await ValorantInfoRepo.mark_mmr_history_backfill_attempt(conn, user_id, error)
+
+    async def mark_mmr_history_backfilled(self, user_id: int) -> None:
+        async with self._db.transaction() as conn:
+            await ValorantInfoRepo.mark_mmr_history_backfilled(conn, user_id)
 
     # ==================== stats ====================
 

--- a/integrations/henrikdev/service.py
+++ b/integrations/henrikdev/service.py
@@ -168,15 +168,15 @@ class HenrikDevService:
         puuid: str,
         *,
         size: int | None = None,
-        start: int | None = None,
+        page: int | None = None,
     ):
         
         url = f"{self.BASE_URL}/v2/by-puuid/stored-mmr-history/{region}/{platform}/{puuid}"
         params: dict[str, int] = {}
         if size is not None:
             params["size"] = size
-        if start is not None:
-            params["start"] = start
+        if page is not None:
+            params["page"] = page
         resp = await self._client.get(
             url,
             params=params or None,

--- a/integrations/henrikdev/service.py
+++ b/integrations/henrikdev/service.py
@@ -161,10 +161,27 @@ class HenrikDevService:
         
         return model, rl
 
-    async def get_stored_mmr_history_by_puuid(self, region: str, platform: str, puuid: str):
+    async def get_stored_mmr_history_by_puuid(
+        self,
+        region: str,
+        platform: str,
+        puuid: str,
+        *,
+        size: int | None = None,
+        start: int | None = None,
+    ):
         
         url = f"{self.BASE_URL}/v2/by-puuid/stored-mmr-history/{region}/{platform}/{puuid}"
-        resp = await self._client.get(url, headers=self._header)
+        params: dict[str, int] = {}
+        if size is not None:
+            params["size"] = size
+        if start is not None:
+            params["start"] = start
+        resp = await self._client.get(
+            url,
+            params=params or None,
+            headers=self._header,
+        )
 
         rl = resp.ratelimit()
         logger.debug("RateLimit: remaining=%s/%s reset=%ss bucket=%s version=%s",

--- a/tests/test_mmr_stats_service.py
+++ b/tests/test_mmr_stats_service.py
@@ -90,6 +90,21 @@ def test_calculate_mmr_stats_keeps_tracker_snapshots_after_imports() -> None:
     assert stats.elos_plot == [1010, 1030]
 
 
+def test_calculate_mmr_stats_dedupes_aggregated_tracker_snapshot_after_imports() -> None:
+    history = [
+        _row_at(10, 0, 1010, match_id="m1", rr_delta=10, source="henrik_live"),
+        _row_at(10, 30, 1025, match_id="m2", rr_delta=15, source="henrik_live"),
+        _row_at(11, 0, 1025, rr_delta=25, source="tracker_snapshot"),
+    ]
+
+    stats = calculate_mmr_stats(history, start_date=date(2026, 5, 8))
+
+    assert stats is not None
+    assert stats.total_games == 2
+    assert stats.total_change == 25
+    assert stats.elos_plot == [1010, 1025]
+
+
 def test_calculate_mmr_stats_ignores_first_filtered_legacy_delta() -> None:
     stats = calculate_mmr_stats(
         [

--- a/tests/test_mmr_stats_service.py
+++ b/tests/test_mmr_stats_service.py
@@ -75,6 +75,51 @@ def test_calculate_mmr_stats_prefers_henrik_matches_over_tracker_snapshots() -> 
     assert stats.elos_plot == [1010, 1000, 1025, 1041]
 
 
+def test_calculate_mmr_stats_keeps_tracker_snapshots_after_imports() -> None:
+    history = [
+        _row_at(10, 0, 1010, match_id="m1", rr_delta=10, source="henrik_live"),
+        _row_at(10, 5, 1010, rr_delta=10, source="tracker_snapshot"),
+        _row_at(11, 0, 1030, rr_delta=20, source="tracker_snapshot"),
+    ]
+
+    stats = calculate_mmr_stats(history, start_date=date(2026, 5, 8))
+
+    assert stats is not None
+    assert stats.total_games == 2
+    assert stats.total_change == 30
+    assert stats.elos_plot == [1010, 1030]
+
+
+def test_calculate_mmr_stats_ignores_first_filtered_legacy_delta() -> None:
+    stats = calculate_mmr_stats(
+        [
+            _row(7, 1000, rr_delta=35, source="legacy"),
+            _row(8, 1015, rr_delta=15, source="legacy"),
+        ],
+        start_date=None,
+    )
+
+    assert stats is not None
+    assert stats.total_games == 1
+    assert stats.total_change == 15
+    assert stats.elos_plot == [1000, 1015]
+
+
+def test_calculate_mmr_stats_keeps_baseline_for_single_metadata_change() -> None:
+    stats = calculate_mmr_stats(
+        [
+            _row(7, 1000, rr_delta=None, source="legacy"),
+            _row(8, 1020, rr_delta=20, source="legacy"),
+        ],
+        start_date=None,
+    )
+
+    assert stats is not None
+    assert stats.total_games == 1
+    assert stats.total_change == 20
+    assert stats.elos_plot == [1000, 1020]
+
+
 def test_calculate_mmr_stats_returns_none_without_enough_filtered_points() -> None:
     stats = calculate_mmr_stats(
         [_row(6, 100), _row(7, 120)],

--- a/tests/test_mmr_stats_service.py
+++ b/tests/test_mmr_stats_service.py
@@ -72,7 +72,7 @@ def test_calculate_mmr_stats_prefers_henrik_matches_over_tracker_snapshots() -> 
     assert stats.avg_win == 17
     assert stats.avg_loss == -10
     assert stats.last_diff == 16
-    assert stats.elos_plot == [1010, 1000, 1025, 1041]
+    assert stats.elos_plot == [1000, 1010, 1000, 1025, 1041]
 
 
 def test_calculate_mmr_stats_keeps_tracker_snapshots_after_imports() -> None:
@@ -87,7 +87,7 @@ def test_calculate_mmr_stats_keeps_tracker_snapshots_after_imports() -> None:
     assert stats is not None
     assert stats.total_games == 2
     assert stats.total_change == 30
-    assert stats.elos_plot == [1010, 1030]
+    assert stats.elos_plot == [1000, 1010, 1030]
 
 
 def test_calculate_mmr_stats_dedupes_aggregated_tracker_snapshot_after_imports() -> None:
@@ -102,7 +102,7 @@ def test_calculate_mmr_stats_dedupes_aggregated_tracker_snapshot_after_imports()
     assert stats is not None
     assert stats.total_games == 2
     assert stats.total_change == 25
-    assert stats.elos_plot == [1010, 1025]
+    assert stats.elos_plot == [1000, 1010, 1025]
 
 
 def test_calculate_mmr_stats_counts_zero_rr_imported_matches() -> None:
@@ -118,7 +118,19 @@ def test_calculate_mmr_stats_counts_zero_rr_imported_matches() -> None:
     assert stats.total_games == 3
     assert stats.total_change == 5
     assert stats.last_diff == -5
-    assert stats.elos_plot == [1010, 1010, 1005]
+    assert stats.elos_plot == [1000, 1010, 1010, 1005]
+
+
+def test_calculate_mmr_stats_adds_baseline_for_single_imported_match() -> None:
+    stats = calculate_mmr_stats(
+        [_row_at(10, 0, 1010, match_id="m1", rr_delta=10, source="henrik_live")],
+        start_date=date(2026, 5, 8),
+    )
+
+    assert stats is not None
+    assert stats.total_games == 1
+    assert stats.total_change == 10
+    assert stats.elos_plot == [1000, 1010]
 
 
 def test_calculate_mmr_stats_ignores_first_filtered_legacy_delta() -> None:

--- a/tests/test_mmr_stats_service.py
+++ b/tests/test_mmr_stats_service.py
@@ -4,8 +4,20 @@ from types import SimpleNamespace
 from cogs.ranking.services.mmr_stats_service import calculate_mmr_stats, parse_mmr_period
 
 
-def _row(day: int, elo: int) -> SimpleNamespace:
-    return SimpleNamespace(recorded_at=datetime(2026, 5, day, tzinfo=timezone.utc), elo=elo)
+def _row(day: int, elo: int, **metadata) -> SimpleNamespace:
+    return SimpleNamespace(
+        recorded_at=datetime(2026, 5, day, tzinfo=timezone.utc),
+        elo=elo,
+        **metadata,
+    )
+
+
+def _row_at(hour: int, minute: int, elo: int, **metadata) -> SimpleNamespace:
+    return SimpleNamespace(
+        recorded_at=datetime(2026, 5, 8, hour, minute, tzinfo=timezone.utc),
+        elo=elo,
+        **metadata,
+    )
 
 
 def test_parse_mmr_period_standard_values() -> None:
@@ -38,6 +50,29 @@ def test_calculate_mmr_stats_filters_and_calculates_diffs() -> None:
     assert stats.avg_loss == -10
     assert stats.last_diff == 30
     assert stats.elos_plot == [120, 110, 140]
+
+
+def test_calculate_mmr_stats_prefers_henrik_matches_over_tracker_snapshots() -> None:
+    history = [
+        _row_at(10, 0, 1010, match_id="m1", rr_delta=10, source="henrik_live"),
+        _row_at(10, 5, 1010, rr_delta=10, source="tracker_snapshot"),
+        _row_at(11, 0, 1000, match_id="m2", rr_delta=-10, source="henrik_live"),
+        _row_at(11, 5, 1000, rr_delta=-10, source="tracker_snapshot"),
+        _row_at(12, 0, 1025, match_id="m3", rr_delta=25, source="henrik_live"),
+        _row_at(12, 5, 1025, rr_delta=25, source="tracker_snapshot"),
+        _row_at(13, 0, 1041, match_id="m4", rr_delta=16, source="henrik_live"),
+        _row_at(13, 5, 1041, rr_delta=16, source="tracker_snapshot"),
+    ]
+
+    stats = calculate_mmr_stats(history, start_date=date(2026, 5, 8))
+
+    assert stats is not None
+    assert stats.total_games == 4
+    assert stats.total_change == 41
+    assert stats.avg_win == 17
+    assert stats.avg_loss == -10
+    assert stats.last_diff == 16
+    assert stats.elos_plot == [1010, 1000, 1025, 1041]
 
 
 def test_calculate_mmr_stats_returns_none_without_enough_filtered_points() -> None:

--- a/tests/test_mmr_stats_service.py
+++ b/tests/test_mmr_stats_service.py
@@ -105,6 +105,22 @@ def test_calculate_mmr_stats_dedupes_aggregated_tracker_snapshot_after_imports()
     assert stats.elos_plot == [1010, 1025]
 
 
+def test_calculate_mmr_stats_counts_zero_rr_imported_matches() -> None:
+    history = [
+        _row_at(10, 0, 1010, match_id="m1", rr_delta=10, source="henrik_live"),
+        _row_at(11, 0, 1010, match_id="m2", rr_delta=0, source="henrik_live"),
+        _row_at(12, 0, 1005, match_id="m3", rr_delta=-5, source="henrik_live"),
+    ]
+
+    stats = calculate_mmr_stats(history, start_date=date(2026, 5, 8))
+
+    assert stats is not None
+    assert stats.total_games == 3
+    assert stats.total_change == 5
+    assert stats.last_diff == -5
+    assert stats.elos_plot == [1010, 1010, 1005]
+
+
 def test_calculate_mmr_stats_ignores_first_filtered_legacy_delta() -> None:
     stats = calculate_mmr_stats(
         [

--- a/tests/test_mmr_tracker_service.py
+++ b/tests/test_mmr_tracker_service.py
@@ -18,12 +18,17 @@ class FakeValorantDb:
         self.calls: list[tuple[str, tuple[object, ...]]] = []
         self.last_history_row = None
         self.info = None
+        self.latest_partition = None
         self.backfill_attempts: list[tuple[int, str | None]] = []
         self.backfilled: list[int] = []
 
     async def get_last_history_row(self, user_id: int, puuid: str | None = None):
         self.calls.append(("get_last_history_row", (user_id, puuid)))
         return self.last_history_row
+
+    async def get_latest_partition(self):
+        self.calls.append(("get_latest_partition", ()))
+        return self.latest_partition
 
     async def ensure_partitions(self, season: int, act: int) -> None:
         self.calls.append(("ensure_partitions", (season, act)))
@@ -212,6 +217,32 @@ async def test_record_current_mmr_snapshot_skips_unchanged_elo():
 
     assert inserted is False
     assert db.calls == [("get_last_history_row", (10, "puuid-1"))]
+
+
+@pytest.mark.asyncio
+async def test_record_current_mmr_snapshot_falls_back_to_latest_partition():
+    db = FakeValorantDb()
+    db.latest_partition = (8, 2)
+    db.last_history_row = ns(elo=520)
+    service = MmrTrackerService(db, object())
+
+    inserted = await service.record_current_mmr_snapshot(
+        {
+            "user_id": 10,
+            "puuid": "puuid-1",
+            "region": "eu",
+            "platform": "pc",
+            "elo": 542,
+            "current_season": None,
+            "current_act": None,
+            "mmr_history_backfilled_at": datetime.now(timezone.utc),
+        },
+    )
+
+    assert inserted is True
+    assert db.calls[0] == ("get_latest_partition", ())
+    assert db.calls[1] == ("get_last_history_row", (10, "puuid-1"))
+    assert db.calls[2] == ("ensure_partitions", (8, 2))
 
 
 @pytest.mark.asyncio

--- a/tests/test_mmr_tracker_service.py
+++ b/tests/test_mmr_tracker_service.py
@@ -406,6 +406,26 @@ async def test_fetch_full_history_returns_rate_limited():
 
 
 @pytest.mark.asyncio
+async def test_fetch_full_history_returns_error_on_stored_failure_without_live_fallback():
+    db = FakeValorantDb()
+    db.info = player_info()
+    service = MmrTrackerService(
+        db,
+        FakeHenrik(
+            stored_error=RuntimeError("stored page failed"),
+            live=ns(status=200, data=ns(history=[history_entry()])),
+        ),
+    )
+
+    result = await service.fetch_full_history(123)
+
+    assert result.status == "error"
+    assert result.error == "stored page failed"
+    assert db.backfill_attempts == [(10, None), (10, "stored page failed")]
+    assert db.backfilled == []
+
+
+@pytest.mark.asyncio
 async def test_fetch_full_history_returns_error_on_live_failure():
     db = FakeValorantDb()
     db.info = player_info()

--- a/tests/test_mmr_tracker_service.py
+++ b/tests/test_mmr_tracker_service.py
@@ -69,17 +69,36 @@ class FakeValorantDb:
 
 
 class FakeHenrik:
-    def __init__(self, *, stored=None, live=None, stored_error=None, live_error=None):
+    def __init__(
+        self,
+        *,
+        stored=None,
+        stored_pages=None,
+        live=None,
+        stored_error=None,
+        live_error=None,
+    ):
         self.stored = stored
+        self.stored_pages = stored_pages
         self.live = live
         self.stored_error = stored_error
         self.live_error = live_error
         self.calls: list[tuple[str, tuple[object, ...]]] = []
 
-    async def get_stored_mmr_history_by_puuid(self, region: str, platform: str, puuid: str):
-        self.calls.append(("stored", (region, platform, puuid)))
+    async def get_stored_mmr_history_by_puuid(
+        self,
+        region: str,
+        platform: str,
+        puuid: str,
+        *,
+        start=None,
+        size=None,
+    ):
+        self.calls.append(("stored", (region, platform, puuid, start, size)))
         if self.stored_error:
             raise self.stored_error
+        if self.stored_pages is not None:
+            return self.stored_pages[start], None
         return self.stored, None
 
     async def get_mmr_history_by_puuid(self, region: str, platform: str, puuid: str):
@@ -112,6 +131,18 @@ def history_entry(**overrides):
     }
     values.update(overrides)
     return ns(**values)
+
+
+def stored_response(entries, *, total=None, returned=None, before=0, after=0):
+    if total is None:
+        total = len(entries)
+    if returned is None:
+        returned = len(entries)
+    return ns(
+        status=200,
+        data=entries,
+        results=ns(total=total, returned=returned, before=before, after=after),
+    )
 
 
 @pytest.mark.asyncio
@@ -270,10 +301,46 @@ async def test_fetch_full_history_imports_stored_history():
     assert result.status == "imported"
     assert result.inserted_count == 1
     assert result.source == "henrik_stored"
-    assert henrik.calls == [("stored", ("eu", "pc", "puuid-1"))]
+    assert henrik.calls == [("stored", ("eu", "pc", "puuid-1", None, None))]
     assert db.backfill_attempts == [(10, None)]
     assert db.backfilled == [10]
     assert db.calls[-1][1][-4:] == ("puuid-1", -16, "match-1", "henrik_stored")
+
+
+@pytest.mark.asyncio
+async def test_fetch_full_history_imports_all_stored_pages():
+    db = FakeValorantDb()
+    db.info = player_info()
+    henrik = FakeHenrik(
+        stored_pages={
+            None: stored_response(
+                [history_entry(match_id="match-1"), history_entry(match_id="match-2")],
+                total=3,
+                returned=2,
+                before=0,
+                after=1,
+            ),
+            2: stored_response(
+                [history_entry(match_id="match-3")],
+                total=3,
+                returned=1,
+                before=2,
+                after=0,
+            ),
+        },
+    )
+    service = MmrTrackerService(db, henrik)
+
+    result = await service.fetch_full_history(123)
+
+    assert result.status == "imported"
+    assert result.inserted_count == 3
+    assert result.source == "henrik_stored"
+    assert henrik.calls == [
+        ("stored", ("eu", "pc", "puuid-1", None, None)),
+        ("stored", ("eu", "pc", "puuid-1", 2, 2)),
+    ]
+    assert db.backfilled == [10]
 
 
 @pytest.mark.asyncio
@@ -291,7 +358,7 @@ async def test_fetch_full_history_falls_back_to_live_history():
     assert result.status == "imported"
     assert result.source == "henrik_live"
     assert henrik.calls == [
-        ("stored", ("eu", "pc", "puuid-1")),
+        ("stored", ("eu", "pc", "puuid-1", None, None)),
         ("live", ("eu", "pc", "puuid-1")),
     ]
     assert db.calls[-1][1][-4:] == ("puuid-1", 24, "live-1", "henrik_live")

--- a/tests/test_mmr_tracker_service.py
+++ b/tests/test_mmr_tracker_service.py
@@ -91,14 +91,14 @@ class FakeHenrik:
         platform: str,
         puuid: str,
         *,
-        start=None,
+        page=None,
         size=None,
     ):
-        self.calls.append(("stored", (region, platform, puuid, start, size)))
+        self.calls.append(("stored", (region, platform, puuid, page, size)))
         if self.stored_error:
             raise self.stored_error
         if self.stored_pages is not None:
-            return self.stored_pages[start], None
+            return self.stored_pages[page], None
         return self.stored, None
 
     async def get_mmr_history_by_puuid(self, region: str, platform: str, puuid: str):

--- a/tests/test_mmr_tracker_service.py
+++ b/tests/test_mmr_tracker_service.py
@@ -1,23 +1,29 @@
 from __future__ import annotations
 
-import pytest
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
+import pytest
+
 from cogs.ranking.services.mmr_tracker_service import MmrTrackerService
+from integrations.exceptions import RateLimitError
+
+
+def ns(**kwargs):
+    return SimpleNamespace(**kwargs)
 
 
 class FakeValorantDb:
     def __init__(self):
         self.calls: list[tuple[str, tuple[object, ...]]] = []
         self.last_history_row = None
-        self.latest_partition = (8, 2)
+        self.info = None
+        self.backfill_attempts: list[tuple[int, str | None]] = []
+        self.backfilled: list[int] = []
 
-    async def get_last_history_row(self, user_id: int):
+    async def get_last_history_row(self, user_id: int, puuid: str | None = None):
+        self.calls.append(("get_last_history_row", (user_id, puuid)))
         return self.last_history_row
-
-    async def get_latest_partition(self):
-        return self.latest_partition
 
     async def ensure_partitions(self, season: int, act: int) -> None:
         self.calls.append(("ensure_partitions", (season, act)))
@@ -30,26 +36,106 @@ class FakeValorantDb:
         recorded_at,
         elo: int,
         is_win: bool,
-    ) -> None:
+        *,
+        puuid: str | None = None,
+        rr_delta: int | None = None,
+        match_id: str | None = None,
+        source: str = "tracker_snapshot",
+    ) -> bool:
         self.calls.append(
-            ("insert_history_entry", (user_id, season, act, recorded_at, elo, is_win))
+            (
+                "insert_history_entry",
+                (user_id, season, act, recorded_at, elo, is_win, puuid, rr_delta, match_id, source),
+            )
         )
+        return True
+
+    async def get_valorant_info_by_discord_id(self, discord_id: int):
+        self.calls.append(("get_valorant_info_by_discord_id", (discord_id,)))
+        return self.info
+
+    async def mark_mmr_history_backfill_attempt(
+        self, user_id: int, error: str | None = None
+    ) -> None:
+        self.backfill_attempts.append((user_id, error))
+
+    async def mark_mmr_history_backfilled(self, user_id: int) -> None:
+        self.backfilled.append(user_id)
+
+
+class FakeHenrik:
+    def __init__(self, *, stored=None, live=None, stored_error=None, live_error=None):
+        self.stored = stored
+        self.live = live
+        self.stored_error = stored_error
+        self.live_error = live_error
+        self.calls: list[tuple[str, tuple[object, ...]]] = []
+
+    async def get_stored_mmr_history_by_puuid(self, region: str, platform: str, puuid: str):
+        self.calls.append(("stored", (region, platform, puuid)))
+        if self.stored_error:
+            raise self.stored_error
+        return self.stored, None
+
+    async def get_mmr_history_by_puuid(self, region: str, platform: str, puuid: str):
+        self.calls.append(("live", (region, platform, puuid)))
+        if self.live_error:
+            raise self.live_error
+        return self.live, None
+
+
+def player_info(**overrides):
+    values = {
+        "user_id": 10,
+        "puuid": "puuid-1",
+        "region": "eu",
+        "platform": "pc",
+        "mmr_history_backfilled_at": None,
+    }
+    values.update(overrides)
+    return ns(**values)
+
+
+def history_entry(**overrides):
+    values = {
+        "date": datetime(2026, 5, 8, 12, 0, tzinfo=timezone.utc),
+        "season": ns(short="e8a2"),
+        "elo": 542,
+        "rr": 99,
+        "last_change": -16,
+        "match_id": "match-1",
+    }
+    values.update(overrides)
+    return ns(**values)
 
 
 @pytest.mark.asyncio
-async def test_insert_history_entry_parses_episode_act_and_inserts():
+async def test_insert_history_entry_stores_metadata_and_uses_delta_for_is_win():
     db = FakeValorantDb()
     service = MmrTrackerService(db, object())
     recorded_at = datetime(2026, 5, 8, tzinfo=timezone.utc)
 
-    await service.insert_history_entry(
+    inserted = await service.insert_history_entry(
         10,
-        {"date": recorded_at, "season": {"short": "e8a2"}, "elo": 542, "rr": 19},
+        {
+            "date": recorded_at,
+            "season": {"short": "e8a2"},
+            "elo": 542,
+            "rr": 99,
+            "rr_delta": -16,
+            "match_id": "match-1",
+        },
+        puuid="puuid-1",
+        source="henrik_live",
     )
 
+    assert inserted is True
     assert db.calls == [
         ("ensure_partitions", (8, 2)),
-        ("insert_history_entry", (10, 8, 2, recorded_at, 542, True)),
+        (
+            "insert_history_entry",
+            (10, 8, 2, recorded_at, 542, False, "puuid-1", -16, "match-1", "henrik_live"),
+        ),
     ]
 
 
@@ -58,36 +144,79 @@ async def test_insert_history_entry_ignores_invalid_season():
     db = FakeValorantDb()
     service = MmrTrackerService(db, object())
 
-    await service.insert_history_entry(
+    inserted = await service.insert_history_entry(
         10,
         {"date": datetime.now(timezone.utc), "season": {"short": "episode-8-act-2"}, "elo": 542, "rr": 19},
     )
 
+    assert inserted is False
     assert db.calls == []
 
 
 @pytest.mark.asyncio
-async def test_record_current_mmr_snapshot_inserts_when_elo_changed():
+async def test_record_current_mmr_snapshot_inserts_when_elo_changed_for_current_puuid():
     db = FakeValorantDb()
-    db.last_history_row = SimpleNamespace(elo=520)
+    db.last_history_row = ns(elo=520)
     service = MmrTrackerService(db, object())
 
     inserted = await service.record_current_mmr_snapshot(
-        {"user_id": 10, "elo": 542, "current_season": 8, "current_act": 2},
+        {
+            "user_id": 10,
+            "puuid": "puuid-1",
+            "region": "eu",
+            "platform": "pc",
+            "elo": 542,
+            "current_season": 8,
+            "current_act": 2,
+            "mmr_history_backfilled_at": datetime.now(timezone.utc),
+        },
     )
 
     assert inserted is True
-    assert db.calls[0] == ("ensure_partitions", (8, 2))
-    assert db.calls[1][0] == "insert_history_entry"
-    user_id, season, act, recorded_at, elo, is_win = db.calls[1][1]
-    assert (user_id, season, act, elo, is_win) == (10, 8, 2, 542, True)
+    assert db.calls[0] == ("get_last_history_row", (10, "puuid-1"))
+    assert db.calls[1] == ("ensure_partitions", (8, 2))
+    assert db.calls[2][0] == "insert_history_entry"
+    user_id, season, act, recorded_at, elo, is_win, puuid, rr_delta, match_id, source = db.calls[2][1]
+    assert (user_id, season, act, elo, is_win, puuid, rr_delta, match_id, source) == (
+        10,
+        8,
+        2,
+        542,
+        True,
+        "puuid-1",
+        22,
+        None,
+        "tracker_snapshot",
+    )
     assert recorded_at.tzinfo is not None
 
 
 @pytest.mark.asyncio
 async def test_record_current_mmr_snapshot_skips_unchanged_elo():
     db = FakeValorantDb()
-    db.last_history_row = SimpleNamespace(elo=542)
+    db.last_history_row = ns(elo=542)
+    service = MmrTrackerService(db, object())
+
+    inserted = await service.record_current_mmr_snapshot(
+        {
+            "user_id": 10,
+            "puuid": "puuid-1",
+            "region": "eu",
+            "platform": "pc",
+            "elo": 542,
+            "current_season": 8,
+            "current_act": 2,
+            "mmr_history_backfilled_at": datetime.now(timezone.utc),
+        },
+    )
+
+    assert inserted is False
+    assert db.calls == [("get_last_history_row", (10, "puuid-1"))]
+
+
+@pytest.mark.asyncio
+async def test_record_current_mmr_snapshot_skips_incomplete_account():
+    db = FakeValorantDb()
     service = MmrTrackerService(db, object())
 
     inserted = await service.record_current_mmr_snapshot(
@@ -96,3 +225,122 @@ async def test_record_current_mmr_snapshot_skips_unchanged_elo():
 
     assert inserted is False
     assert db.calls == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_full_history_imports_stored_history():
+    db = FakeValorantDb()
+    db.info = player_info()
+    henrik = FakeHenrik(stored=ns(status=200, data=[history_entry()]))
+    service = MmrTrackerService(db, henrik)
+
+    result = await service.fetch_full_history(123)
+
+    assert result.status == "imported"
+    assert result.inserted_count == 1
+    assert result.source == "henrik_stored"
+    assert henrik.calls == [("stored", ("eu", "pc", "puuid-1"))]
+    assert db.backfill_attempts == [(10, None)]
+    assert db.backfilled == [10]
+    assert db.calls[-1][1][-4:] == ("puuid-1", -16, "match-1", "henrik_stored")
+
+
+@pytest.mark.asyncio
+async def test_fetch_full_history_falls_back_to_live_history():
+    db = FakeValorantDb()
+    db.info = player_info()
+    henrik = FakeHenrik(
+        stored=ns(status=200, data=[]),
+        live=ns(status=200, data=ns(history=[history_entry(match_id="live-1", last_change=24)])),
+    )
+    service = MmrTrackerService(db, henrik)
+
+    result = await service.fetch_full_history(123)
+
+    assert result.status == "imported"
+    assert result.source == "henrik_live"
+    assert henrik.calls == [
+        ("stored", ("eu", "pc", "puuid-1")),
+        ("live", ("eu", "pc", "puuid-1")),
+    ]
+    assert db.calls[-1][1][-4:] == ("puuid-1", 24, "live-1", "henrik_live")
+
+
+@pytest.mark.asyncio
+async def test_fetch_full_history_returns_pending_when_account_is_not_synced():
+    db = FakeValorantDb()
+    db.info = player_info(puuid=None)
+    service = MmrTrackerService(db, FakeHenrik())
+
+    result = await service.fetch_full_history(123)
+
+    assert result.status == "pending_sync"
+    assert db.backfill_attempts == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_full_history_returns_empty_when_api_has_no_history():
+    db = FakeValorantDb()
+    db.info = player_info()
+    service = MmrTrackerService(
+        db,
+        FakeHenrik(stored=ns(status=200, data=[]), live=ns(status=200, data=ns(history=[]))),
+    )
+
+    result = await service.fetch_full_history(123)
+
+    assert result.status == "empty"
+    assert db.backfill_attempts == [(10, None), (10, "empty")]
+    assert db.backfilled == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_full_history_returns_rate_limited():
+    db = FakeValorantDb()
+    db.info = player_info()
+    service = MmrTrackerService(db, FakeHenrik(stored_error=RateLimitError("limited")))
+
+    result = await service.fetch_full_history(123)
+
+    assert result.status == "rate_limited"
+    assert db.backfill_attempts == [(10, None), (10, "rate_limited")]
+    assert db.backfilled == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_full_history_returns_error_on_live_failure():
+    db = FakeValorantDb()
+    db.info = player_info()
+    service = MmrTrackerService(
+        db,
+        FakeHenrik(stored=ns(status=200, data=[]), live_error=RuntimeError("downstream failed")),
+    )
+
+    result = await service.fetch_full_history(123)
+
+    assert result.status == "error"
+    assert result.error == "downstream failed"
+    assert db.backfill_attempts == [(10, None), (10, "downstream failed")]
+
+
+@pytest.mark.asyncio
+async def test_tracked_row_backfill_is_throttled_by_attempted_at():
+    db = FakeValorantDb()
+    service = MmrTrackerService(db, FakeHenrik())
+
+    inserted = await service.record_current_mmr_snapshot(
+        {
+            "user_id": 10,
+            "puuid": "puuid-1",
+            "region": "eu",
+            "platform": "pc",
+            "elo": 542,
+            "current_season": 8,
+            "current_act": 2,
+            "mmr_history_backfilled_at": None,
+            "mmr_history_backfill_attempted_at": datetime.now(timezone.utc) - timedelta(minutes=5),
+        },
+    )
+
+    assert inserted is True
+    assert db.backfill_attempts == []

--- a/tests/test_mmr_tracker_service.py
+++ b/tests/test_mmr_tracker_service.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 import pytest
 
 from cogs.ranking.services.mmr_tracker_service import MmrTrackerService
-from integrations.exceptions import RateLimitError
+from integrations.exceptions import ApiError, RateLimitError
 
 
 def ns(**kwargs):
@@ -403,6 +403,26 @@ async def test_fetch_full_history_returns_rate_limited():
     assert result.status == "rate_limited"
     assert db.backfill_attempts == [(10, None), (10, "rate_limited")]
     assert db.backfilled == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_full_history_falls_back_to_live_when_stored_is_missing():
+    db = FakeValorantDb()
+    db.info = player_info()
+    service = MmrTrackerService(
+        db,
+        FakeHenrik(
+            stored_error=ApiError("HTTP 404: not found"),
+            live=ns(status=200, data=ns(history=[history_entry(match_id="live-1")])),
+        ),
+    )
+
+    result = await service.fetch_full_history(123)
+
+    assert result.status == "imported"
+    assert result.source == "henrik_live"
+    assert db.backfill_attempts == [(10, None)]
+    assert db.backfilled == [10]
 
 
 @pytest.mark.asyncio

--- a/tests/test_schema_contract.py
+++ b/tests/test_schema_contract.py
@@ -87,6 +87,18 @@ def test_simple_v2_backfill_migration_is_non_destructive() -> None:
     assert "INSERT INTO VALORANT_SENT_BUNDLES_V2" in migration
 
 
+def test_mmr_history_metadata_migration_is_additive() -> None:
+    migration = _migration_text("029_mmr_history_metadata.sql")
+
+    _assert_non_destructive(migration)
+    assert "ADD COLUMN IF NOT EXISTS PUUID" in migration
+    assert "ADD COLUMN IF NOT EXISTS RR_DELTA" in migration
+    assert "ADD COLUMN IF NOT EXISTS MATCH_ID" in migration
+    assert "ADD COLUMN IF NOT EXISTS SOURCE" in migration
+    assert "ADD COLUMN IF NOT EXISTS MMR_HISTORY_BACKFILLED_AT" in migration
+    assert "IDX_VALORANT_ELO_HISTORY_USER_PUUID_RECORDED_AT" in migration
+
+
 @pytest.mark.parametrize(
     ("name", "expected_fragments"),
     [

--- a/tests/test_schema_contract.py
+++ b/tests/test_schema_contract.py
@@ -97,6 +97,7 @@ def test_mmr_history_metadata_migration_is_additive() -> None:
     assert "ADD COLUMN IF NOT EXISTS SOURCE" in migration
     assert "ADD COLUMN IF NOT EXISTS MMR_HISTORY_BACKFILLED_AT" in migration
     assert "IDX_VALORANT_ELO_HISTORY_USER_PUUID_RECORDED_AT" in migration
+    assert "SET PUUID = VI.PUUID" not in migration
 
 
 @pytest.mark.parametrize(

--- a/tests/test_valorant_db_service.py
+++ b/tests/test_valorant_db_service.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import pytest
 
+from database.repos.user_repo import UserRepo
+from database.repos.valorant_elo_history_repo import ValorantEloHistoryRepo
 from database.repos.valorant_info_repo import (
+    ValorantInfoRow,
     ValorantInfoRepo,
     ValorantUserPresenceRow,
 )
@@ -17,9 +20,20 @@ class FakeTransaction:
         return False
 
 
+class FakeAcquire:
+    async def __aenter__(self):
+        return "conn"
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
 class FakeDb:
     def transaction(self):
         return FakeTransaction()
+
+    def acquire(self):
+        return FakeAcquire()
 
 
 @pytest.mark.asyncio
@@ -63,3 +77,105 @@ async def test_sync_presence_uses_repo_batch_methods(monkeypatch):
         ("active", ("conn", [1, 3])),
         ("inactive", ("conn", [2])),
     ]
+
+
+@pytest.mark.asyncio
+async def test_get_history_reads_legacy_rows_while_puuid_is_pending(monkeypatch):
+    calls: list[tuple[str, object]] = []
+
+    async def get_user_id(conn, discord_id):
+        calls.append(("get_user_id", (conn, discord_id)))
+        return 10
+
+    async def get_by_user_id(conn, user_id):
+        calls.append(("get_by_user_id", (conn, user_id)))
+        return ValorantInfoRow(
+            user_id=user_id,
+            pseudo="Player",
+            tag="EUW",
+            puuid=None,
+            region=None,
+            platform=None,
+            rank=None,
+            elo=None,
+            current_season=None,
+            current_act=None,
+            is_active=True,
+            tracking_enabled=True,
+            error_count=0,
+            last_error_at=None,
+            last_checked_at=None,
+            last_notification=None,
+            deactivated_at=None,
+            mmr_history_backfilled_at=None,
+            mmr_history_backfill_attempted_at=None,
+            mmr_history_backfill_error=None,
+        )
+
+    async def get_history(conn, user_id, season=None, act=None, puuid=None, legacy_only=False):
+        calls.append(("get_history", (conn, user_id, season, act, puuid, legacy_only)))
+        return ["legacy-row"]
+
+    monkeypatch.setattr(UserRepo, "get_user_id", get_user_id)
+    monkeypatch.setattr(ValorantInfoRepo, "get_by_user_id", get_by_user_id)
+    monkeypatch.setattr(ValorantEloHistoryRepo, "get_history", get_history)
+
+    service = ValorantDbService(FakeDb())
+
+    rows = await service.get_history(123, season=8, act=2)
+
+    assert rows == ["legacy-row"]
+    assert calls[-1] == ("get_history", ("conn", 10, 8, 2, None, True))
+
+
+@pytest.mark.asyncio
+async def test_get_partitions_reads_legacy_rows_while_puuid_is_pending(monkeypatch):
+    calls: list[tuple[str, object]] = []
+
+    async def get_user_id(conn, discord_id):
+        calls.append(("get_user_id", (conn, discord_id)))
+        return 10
+
+    async def get_by_user_id(conn, user_id):
+        calls.append(("get_by_user_id", (conn, user_id)))
+        return ValorantInfoRow(
+            user_id=user_id,
+            pseudo="Player",
+            tag="EUW",
+            puuid=None,
+            region=None,
+            platform=None,
+            rank=None,
+            elo=None,
+            current_season=None,
+            current_act=None,
+            is_active=True,
+            tracking_enabled=True,
+            error_count=0,
+            last_error_at=None,
+            last_checked_at=None,
+            last_notification=None,
+            deactivated_at=None,
+            mmr_history_backfilled_at=None,
+            mmr_history_backfill_attempted_at=None,
+            mmr_history_backfill_error=None,
+        )
+
+    async def get_distinct_partitions(conn, user_id, puuid=None, legacy_only=False):
+        calls.append(("get_partitions", (conn, user_id, puuid, legacy_only)))
+        return [(8, 2)]
+
+    monkeypatch.setattr(UserRepo, "get_user_id", get_user_id)
+    monkeypatch.setattr(ValorantInfoRepo, "get_by_user_id", get_by_user_id)
+    monkeypatch.setattr(
+        ValorantEloHistoryRepo,
+        "get_distinct_partitions",
+        get_distinct_partitions,
+    )
+
+    service = ValorantDbService(FakeDb())
+
+    rows = await service.get_partitions(123)
+
+    assert rows == [(8, 2)]
+    assert calls[-1] == ("get_partitions", ("conn", 10, None, True))

--- a/tests/test_valorant_elo_history_repo.py
+++ b/tests/test_valorant_elo_history_repo.py
@@ -11,6 +11,10 @@ class FakeConnection:
         self.queries.append((query, args))
         return []
 
+    async def fetchrow(self, query: str, *args):
+        self.queries.append((query, args))
+        return None
+
 
 @pytest.mark.asyncio
 async def test_get_history_includes_unscoped_legacy_rows_for_current_puuid():
@@ -31,6 +35,18 @@ async def test_get_distinct_partitions_includes_unscoped_legacy_rows_for_current
     rows = await ValorantEloHistoryRepo.get_distinct_partitions(conn, 10, "puuid-1")
 
     assert rows == []
+    query, args = conn.queries[0]
+    assert args == (10, "puuid-1")
+    assert "puuid = $2 OR (puuid IS NULL AND source = 'legacy')" in query
+
+
+@pytest.mark.asyncio
+async def test_get_last_row_includes_unscoped_legacy_rows_for_current_puuid():
+    conn = FakeConnection()
+
+    row = await ValorantEloHistoryRepo.get_last_row(conn, 10, "puuid-1")
+
+    assert row is None
     query, args = conn.queries[0]
     assert args == (10, "puuid-1")
     assert "puuid = $2 OR (puuid IS NULL AND source = 'legacy')" in query

--- a/tests/test_valorant_elo_history_repo.py
+++ b/tests/test_valorant_elo_history_repo.py
@@ -17,7 +17,7 @@ class FakeConnection:
 
 
 @pytest.mark.asyncio
-async def test_get_history_includes_unscoped_legacy_rows_for_current_puuid():
+async def test_get_history_filters_only_current_puuid_when_known():
     conn = FakeConnection()
 
     rows = await ValorantEloHistoryRepo.get_history(conn, 10, puuid="puuid-1")
@@ -25,11 +25,24 @@ async def test_get_history_includes_unscoped_legacy_rows_for_current_puuid():
     assert rows == []
     query, args = conn.queries[0]
     assert args == (10, "puuid-1")
-    assert "puuid = $2 OR (puuid IS NULL AND source = 'legacy')" in query
+    assert "AND puuid = $2" in query
+    assert "source = 'legacy'" not in query
 
 
 @pytest.mark.asyncio
-async def test_get_distinct_partitions_includes_unscoped_legacy_rows_for_current_puuid():
+async def test_get_history_can_read_only_unscoped_legacy_rows():
+    conn = FakeConnection()
+
+    rows = await ValorantEloHistoryRepo.get_history(conn, 10, legacy_only=True)
+
+    assert rows == []
+    query, args = conn.queries[0]
+    assert args == (10,)
+    assert "puuid IS NULL AND source = 'legacy'" in query
+
+
+@pytest.mark.asyncio
+async def test_get_distinct_partitions_filters_only_current_puuid_when_known():
     conn = FakeConnection()
 
     rows = await ValorantEloHistoryRepo.get_distinct_partitions(conn, 10, "puuid-1")
@@ -37,11 +50,26 @@ async def test_get_distinct_partitions_includes_unscoped_legacy_rows_for_current
     assert rows == []
     query, args = conn.queries[0]
     assert args == (10, "puuid-1")
-    assert "puuid = $2 OR (puuid IS NULL AND source = 'legacy')" in query
+    assert "AND puuid = $2" in query
+    assert "source = 'legacy'" not in query
 
 
 @pytest.mark.asyncio
-async def test_get_last_row_includes_unscoped_legacy_rows_for_current_puuid():
+async def test_get_distinct_partitions_can_read_only_unscoped_legacy_rows():
+    conn = FakeConnection()
+
+    rows = await ValorantEloHistoryRepo.get_distinct_partitions(
+        conn, 10, legacy_only=True
+    )
+
+    assert rows == []
+    query, args = conn.queries[0]
+    assert args == (10,)
+    assert "puuid IS NULL AND source = 'legacy'" in query
+
+
+@pytest.mark.asyncio
+async def test_get_last_row_filters_only_current_puuid_when_known():
     conn = FakeConnection()
 
     row = await ValorantEloHistoryRepo.get_last_row(conn, 10, "puuid-1")
@@ -49,4 +77,17 @@ async def test_get_last_row_includes_unscoped_legacy_rows_for_current_puuid():
     assert row is None
     query, args = conn.queries[0]
     assert args == (10, "puuid-1")
-    assert "puuid = $2 OR (puuid IS NULL AND source = 'legacy')" in query
+    assert "AND puuid = $2" in query
+    assert "source = 'legacy'" not in query
+
+
+@pytest.mark.asyncio
+async def test_get_last_row_can_read_only_unscoped_legacy_rows():
+    conn = FakeConnection()
+
+    row = await ValorantEloHistoryRepo.get_last_row(conn, 10, legacy_only=True)
+
+    assert row is None
+    query, args = conn.queries[0]
+    assert args == (10,)
+    assert "puuid IS NULL AND source = 'legacy'" in query

--- a/tests/test_valorant_elo_history_repo.py
+++ b/tests/test_valorant_elo_history_repo.py
@@ -1,0 +1,36 @@
+import pytest
+
+from database.repos.valorant_elo_history_repo import ValorantEloHistoryRepo
+
+
+class FakeConnection:
+    def __init__(self):
+        self.queries: list[tuple[str, tuple[object, ...]]] = []
+
+    async def fetch(self, query: str, *args):
+        self.queries.append((query, args))
+        return []
+
+
+@pytest.mark.asyncio
+async def test_get_history_includes_unscoped_legacy_rows_for_current_puuid():
+    conn = FakeConnection()
+
+    rows = await ValorantEloHistoryRepo.get_history(conn, 10, puuid="puuid-1")
+
+    assert rows == []
+    query, args = conn.queries[0]
+    assert args == (10, "puuid-1")
+    assert "puuid = $2 OR (puuid IS NULL AND source = 'legacy')" in query
+
+
+@pytest.mark.asyncio
+async def test_get_distinct_partitions_includes_unscoped_legacy_rows_for_current_puuid():
+    conn = FakeConnection()
+
+    rows = await ValorantEloHistoryRepo.get_distinct_partitions(conn, 10, "puuid-1")
+
+    assert rows == []
+    query, args = conn.queries[0]
+    assert args == (10, "puuid-1")
+    assert "puuid = $2 OR (puuid IS NULL AND source = 'legacy')" in query


### PR DESCRIPTION
## Summary
- add additive migration 029 for Valorant MMR history metadata and backfill state
- scope MMR history by current Valorant PUUID and store source/rr_delta/match_id metadata
- fix /mmr_track stats so Henrik match entries are preferred over tracker snapshots, preventing 4 games from being counted as 8
- improve /mmr_track activation feedback for imported/pending/empty/rate-limited/error states

## Validation
- .venv\Scripts\python.exe -m compileall -q bot.py core cogs database integrations tests tools
- .venv\Scripts\python.exe -m pytest -q (216 passed)
- git diff --cached --check

## Risks
- migration 029 is additive but must be tested on a copied VPS test database before production
- pre-existing legacy MMR rows without match_id keep legacy diff-based behavior
- no production deployment, merge, or VPS mutation has been performed by this PR

## Next step
Run the VPS test instance workflow against this branch after review validation: tools/vps/run-test-instance.sh start --copy-prod-db --ref origin/fix-mmr-history-stats